### PR TITLE
Fix login pattern and display player names

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ This repository contains a lightweight prototype inspired by [buzzin.live](https
    ```json
    {
      "users": [
-       { "login": "123", "password": "4567" },
-       { "login": "234", "password": "5678" }
+      { "login": "123", "password": "4567", "name": "Alex Morgan" },
+      { "login": "234", "password": "5678", "name": "Jordan Smith" }
      ]
    }
    ```
 
    - Logins must be exactly three digits.
    - Passwords must be exactly four digits.
+   - `name` is displayed on the dashboard and should include the player's first and last name.
 
 4. Run the development server:
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -2,7 +2,14 @@
 {% block title %}Dashboard · Panenka Live{% endblock %}
 {% block content %}
 <section class="card">
-  <h2 class="card-title">Welcome, Player {{ login_code }}</h2>
+  <h2 class="card-title">
+    Welcome,
+    {% if user_name %}
+      {{ user_name }}
+    {% else %}
+      Player {{ login_code }}
+    {% endif %}
+  </h2>
   <p class="card-description">You're in! We'll soon add buzzers, scoreboards, and more interactive tools.</p>
   <div class="placeholder-grid">
     <article class="placeholder">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -7,11 +7,11 @@
   <form method="post" class="form">
     <label class="field">
       <span class="field-label">Login</span>
-      <input type="text" name="login" inputmode="numeric" pattern="\\d{3}" maxlength="3" required placeholder="123">
+      <input type="text" name="login" inputmode="numeric" pattern="[0-9]{3}" maxlength="3" required placeholder="123">
     </label>
     <label class="field">
       <span class="field-label">Password</span>
-      <input type="password" name="password" inputmode="numeric" pattern="\\d{4}" maxlength="4" required placeholder="1234">
+      <input type="password" name="password" inputmode="numeric" pattern="[0-9]{4}" maxlength="4" required placeholder="1234">
     </label>
     <button type="submit" class="btn-primary">Enter Lobby</button>
   </form>


### PR DESCRIPTION
## Summary
- correct the login form input patterns so valid numeric credentials pass browser validation
- capture player names from `auth.json`, persist them in the session, and render them on the dashboard
- document the updated `auth.json` structure that now includes a `name` field per user

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d6a652039c83238c402869471a1b36