### PR TITLE
Improve S3 credential loading

### DIFF
--- a/tests/test_s3_parsing.py
+++ b/tests/test_s3_parsing.py
@@ -1,0 +1,64 @@
+import unittest
+
+from app.routes import DEFAULT_S3_KEY, _parse_s3_reference
+
+
+class ParseS3ReferenceTestCase(unittest.TestCase):
+    def test_supported_formats(self):
+        cases = [
+            ("s3://my-bucket/auth.json", "my-bucket", "auth.json"),
+            ("s3://my-bucket", "my-bucket", DEFAULT_S3_KEY),
+            (
+                "https://player-creds.s3.amazonaws.com/auth.json",
+                "player-creds",
+                "auth.json",
+            ),
+            (
+                "https://player-creds.s3.us-west-2.amazonaws.com/folder/auth.json",
+                "player-creds",
+                "folder/auth.json",
+            ),
+            (
+                "https://player-creds.s3.dualstack.us-east-1.amazonaws.com/auth.json",
+                "player-creds",
+                "auth.json",
+            ),
+            (
+                "https://s3.us-east-1.amazonaws.com/player-creds/auth.json",
+                "player-creds",
+                "auth.json",
+            ),
+            (
+                "https://s3-accelerate.amazonaws.com/player-creds/auth.json",
+                "player-creds",
+                "auth.json",
+            ),
+            (
+                "https://s3.dualstack.us-east-1.amazonaws.com/player-creds/auth.json",
+                "player-creds",
+                "auth.json",
+            ),
+            ("https://s3.amazonaws.com/player-creds", "player-creds", DEFAULT_S3_KEY),
+            (
+                "https://player-creds.s3-website-us-west-2.amazonaws.com/auth.json",
+                "player-creds",
+                "auth.json",
+            ),
+        ]
+
+        for reference, expected_bucket, expected_key in cases:
+            with self.subTest(reference=reference):
+                bucket, key = _parse_s3_reference(reference)
+                self.assertEqual(bucket, expected_bucket)
+                self.assertEqual(key, expected_key)
+
+    def test_invalid_or_missing_references(self):
+        for reference in ("https://example.com/auth.json", None, ""):
+            with self.subTest(reference=reference):
+                bucket, key = _parse_s3_reference(reference)
+                self.assertIsNone(bucket)
+                self.assertIsNone(key)
+
+
+if __name__ == "__main__":  # pragma: no cover - allows running file directly
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize S3-related environment variables before loading credentials
- expand S3 URL parsing to handle regional and dualstack endpoints before falling back to auth.json
- add unit tests covering the supported S3 URI and URL formats

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d736a5414c8323b09bc7705c201567