### PR TITLE
Add default auth fallback when credentials file missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This repository contains a lightweight prototype inspired by [buzzin.live](https
        `AUTH_JSON_URL` is used, the file is downloaded over HTTPS, which is useful for public buckets that do not require
        AWS credentials.
 
+   If no credentials source is configured, the application falls back to a built-in demo
+   account (`888` / `6969`) so the interface remains usable in hosted environments. You
+   should still provide your own credentials for production deployments.
+
 4. Run the development server:
 
    ```bash

--- a/app/routes.py
+++ b/app/routes.py
@@ -17,6 +17,14 @@ AUTH_S3_URI_ENV = "AUTH_JSON_S3_URI"
 AUTH_JSON_URL_ENV = "AUTH_JSON_URL"
 DEFAULT_S3_KEY = "auth.json"
 
+DEFAULT_FALLBACK_USERS = [
+    {
+        "login": "888",
+        "password": "6969",
+        "name": "Integration Test Player",
+    }
+]
+
 
 class AuthFileMissingError(FileNotFoundError):
     """Raised when the auth.json file is missing."""
@@ -183,7 +191,10 @@ def load_credentials():
             raise ValueError(str(exc)) from exc
 
     if payload is None:
-        payload = _load_from_file()
+        try:
+            payload = _load_from_file()
+        except AuthFileMissingError:
+            payload = {"users": DEFAULT_FALLBACK_USERS}
     users = payload.get("users", [])
     users_by_login = {}
     for user in users:


### PR DESCRIPTION
## Summary
- provide built-in demo credentials when no auth.json source is configured so hosted deployments stay functional
- document the fallback demo account in the README

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d739063f808323be3a9585703dc19d