### PR TITLE
Coerce numeric auth credentials to strings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -200,6 +200,10 @@ def load_credentials():
     for user in users:
         login = user.get("login")
         password = user.get("password")
+        if login is None or password is None:
+            continue
+        login = str(login).strip()
+        password = str(password).strip()
         if not login or not password:
             continue
         users_by_login[login] = {

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -93,6 +93,27 @@ class AuthJsonLoginTestCase(unittest.TestCase):
         self.assertIn(self.LOGIN_CODE, body)
         self.assertIn("Logout", body)
 
+    def test_numeric_credentials_are_coerced_to_strings(self):
+        numeric_payload = {
+            "users": [
+                {
+                    "login": 123,
+                    "password": 4567,
+                    "name": "Numeric Player",
+                }
+            ]
+        }
+
+        os.environ[AUTH_ENV_VAR] = json.dumps(numeric_payload)
+        try:
+            credentials = load_credentials()
+        finally:
+            del os.environ[AUTH_ENV_VAR]
+
+        self.assertIn("123", credentials)
+        self.assertEqual(credentials["123"]["password"], "4567")
+        self.assertEqual(credentials["123"]["name"], "Numeric Player")
+
 
 if __name__ == "__main__":  # pragma: no cover - allows running file directly
     unittest.main()


### PR DESCRIPTION
## Summary
- coerce login and password values from auth.json into stripped strings before validation
- skip malformed credential entries where either login or password is missing
- add a regression test ensuring numeric credential values remain usable

## Testing
- PYTHONPATH=. pytest tests/test_auth_login.py::AuthJsonLoginTestCase::test_numeric_credentials_are_coerced_to_strings

------
https://chatgpt.com/codex/tasks/task_e_68d73a605ad8832396fc017e035fde46