### PR TITLE
Implement buzzer lobby experience

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,10 +1,23 @@
 import json
 import os
+import secrets
+import time
 from functools import wraps
 from pathlib import Path
 from urllib.parse import urlparse
+from uuid import uuid4
 
-from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 
 bp = Blueprint("main", __name__)
 
@@ -25,10 +38,98 @@ DEFAULT_FALLBACK_USERS = [
     }
 ]
 
+LOBBY_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+LOBBY_CODE_LENGTH = 4
+LOBBY_EXPIRATION_SECONDS = 60 * 60
+PLAYER_EXPIRATION_SECONDS = 45
+
+
+LOBBIES = {}
+
 
 class AuthFileMissingError(FileNotFoundError):
     """Raised when the auth.json file is missing."""
 
+
+def _current_display_name():
+    user_name = session.get("user_name")
+    login_code = session.get("user_id")
+    if user_name:
+        return user_name
+    if login_code:
+        return f"Player {login_code}"
+    return "Host"
+
+
+def _clear_buzzer_session():
+    session.pop("buzzer_role", None)
+    session.pop("buzzer_code", None)
+    session.pop("buzzer_id", None)
+    session.pop("buzzer_name", None)
+
+
+def _generate_lobby_code():
+    while True:
+        code = "".join(
+            secrets.choice(LOBBY_CODE_ALPHABET) for _ in range(LOBBY_CODE_LENGTH)
+        )
+        if code not in LOBBIES:
+            return code
+
+
+def _expire_stale_players(lobby, now):
+    removed_ids = []
+    for player_id, player in list(lobby["players"].items()):
+        last_seen = player.get("last_seen", lobby["created_at"])
+        if now - last_seen > PLAYER_EXPIRATION_SECONDS:
+            removed_ids.append(player_id)
+            del lobby["players"][player_id]
+
+    if removed_ids:
+        lobby["buzz_order"] = [
+            player_id for player_id in lobby["buzz_order"] if player_id not in removed_ids
+        ]
+        lobby["updated_at"] = now
+
+
+def _expire_stale_lobbies():
+    now = time.time()
+    expired_codes = []
+    for code, lobby in list(LOBBIES.items()):
+        _expire_stale_players(lobby, now)
+        host_seen = lobby.get("host_seen", lobby["created_at"])
+        if now - lobby.get("updated_at", lobby["created_at"]) > LOBBY_EXPIRATION_SECONDS:
+            expired_codes.append(code)
+        elif now - host_seen > LOBBY_EXPIRATION_SECONDS:
+            expired_codes.append(code)
+        elif not lobby["players"] and now - host_seen > PLAYER_EXPIRATION_SECONDS * 2:
+            expired_codes.append(code)
+
+    for code in expired_codes:
+        del LOBBIES[code]
+
+
+def _remove_player_from_lobby(code, player_id):
+    if not code or not player_id:
+        return
+    lobby = LOBBIES.get(code)
+    if not lobby:
+        return
+
+    if player_id in lobby["players"]:
+        del lobby["players"][player_id]
+        lobby["buzz_order"] = [
+            existing for existing in lobby["buzz_order"] if existing != player_id
+        ]
+        lobby["updated_at"] = time.time()
+
+
+def _get_lobby_or_404(code):
+    _expire_stale_lobbies()
+    lobby = LOBBIES.get(code)
+    if not lobby:
+        abort(404)
+    return lobby
 
 def _get_sanitized_env(name):
     value = os.getenv(name)
@@ -222,6 +323,326 @@ def login_required(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+@bp.route("/buzzer")
+@login_required
+def buzzer_home():
+    _expire_stale_lobbies()
+    code = session.get("buzzer_code")
+    role = session.get("buzzer_role")
+    player_id = session.get("buzzer_id")
+
+    if role == "host" and code in LOBBIES:
+        lobby = LOBBIES.get(code)
+        if lobby and lobby.get("host_id") == player_id:
+            return redirect(url_for("main.buzzer_host", code=code))
+
+    if role == "player" and code in LOBBIES:
+        lobby = LOBBIES.get(code)
+        if lobby and player_id in lobby["players"]:
+            return redirect(url_for("main.buzzer_player", code=code))
+
+    _clear_buzzer_session()
+    requested_code = request.args.get("code", "").strip().upper()
+    return render_template(
+        "buzzer_landing.html",
+        default_name=_current_display_name(),
+        requested_code=requested_code,
+        lobby_code_length=LOBBY_CODE_LENGTH,
+    )
+
+
+@bp.route("/buzzer/create", methods=["POST"])
+@login_required
+def buzzer_create():
+    _expire_stale_lobbies()
+    _clear_buzzer_session()
+
+    code = _generate_lobby_code()
+    host_id = str(uuid4())
+    host_name = _current_display_name()
+    now = time.time()
+
+    LOBBIES[code] = {
+        "code": code,
+        "host_id": host_id,
+        "host_name": host_name,
+        "created_at": now,
+        "updated_at": now,
+        "host_seen": now,
+        "locked": False,
+        "players": {},
+        "buzz_order": [],
+    }
+
+    session["buzzer_role"] = "host"
+    session["buzzer_code"] = code
+    session["buzzer_id"] = host_id
+    session["buzzer_name"] = host_name
+
+    return redirect(url_for("main.buzzer_host", code=code))
+
+
+@bp.route("/buzzer/join", methods=["POST"])
+@login_required
+def buzzer_join():
+    _expire_stale_lobbies()
+    code = request.form.get("code", "").strip().upper()
+    display_name = request.form.get("display_name", "").strip()
+
+    if session.get("buzzer_role") == "player":
+        _remove_player_from_lobby(session.get("buzzer_code"), session.get("buzzer_id"))
+        _clear_buzzer_session()
+
+    if not code or len(code) != LOBBY_CODE_LENGTH:
+        flash("Enter a valid lobby code to join.", "error")
+        return redirect(url_for("main.buzzer_home", code=code))
+
+    lobby = LOBBIES.get(code)
+    if not lobby:
+        flash("We couldn't find a lobby with that code.", "error")
+        return redirect(url_for("main.buzzer_home"))
+
+    if not display_name:
+        display_name = _current_display_name()
+
+    display_name = display_name[:32]
+
+    player_id = str(uuid4())
+    now = time.time()
+    lobby["players"][player_id] = {
+        "id": player_id,
+        "name": display_name,
+        "joined_at": now,
+        "last_seen": now,
+        "buzzed_at": None,
+    }
+    lobby["updated_at"] = now
+
+    session["buzzer_role"] = "player"
+    session["buzzer_code"] = code
+    session["buzzer_id"] = player_id
+    session["buzzer_name"] = display_name
+
+    return redirect(url_for("main.buzzer_player", code=code))
+
+
+@bp.route("/buzzer/host/<code>")
+@login_required
+def buzzer_host(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "host" or session.get("buzzer_id") != lobby["host_id"]:
+        flash("You're not hosting this lobby.", "error")
+        return redirect(url_for("main.buzzer_home"))
+
+    share_url = url_for("main.buzzer_home", _external=True, code=code)
+    return render_template(
+        "buzzer_host.html",
+        code=code,
+        host_name=lobby["host_name"],
+        share_url=share_url,
+    )
+
+
+@bp.route("/buzzer/player/<code>")
+@login_required
+def buzzer_player(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "player" or session.get("buzzer_code") != code:
+        flash("Join the lobby first to buzz in.", "error")
+        return redirect(url_for("main.buzzer_home", code=code))
+
+    player_id = session.get("buzzer_id")
+    if player_id not in lobby["players"]:
+        _clear_buzzer_session()
+        flash("Your session is no longer part of this lobby.", "error")
+        return redirect(url_for("main.buzzer_home"))
+
+    return render_template(
+        "buzzer_player.html",
+        code=code,
+        display_name=session.get("buzzer_name"),
+        host_name=lobby["host_name"],
+    )
+
+
+@bp.route("/buzzer/api/lobbies/<code>/state")
+@login_required
+def buzzer_state(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+    role = session.get("buzzer_role")
+    session_id = session.get("buzzer_id")
+    now = time.time()
+
+    if role == "host" and session_id == lobby["host_id"]:
+        lobby["host_seen"] = now
+    elif role == "player" and session_id in lobby["players"]:
+        lobby["players"][session_id]["last_seen"] = now
+    else:
+        return jsonify({"error": "not-in-lobby"}), 403
+
+    _expire_stale_players(lobby, now)
+
+    players = []
+    for player_id, player in sorted(
+        lobby["players"].items(), key=lambda item: item[1]["joined_at"]
+    ):
+        position = (
+            lobby["buzz_order"].index(player_id) + 1
+            if player_id in lobby["buzz_order"]
+            else None
+        )
+        players.append(
+            {
+                "id": player_id,
+                "name": player["name"],
+                "buzzed": position is not None,
+                "position": position,
+                "is_self": role == "player" and player_id == session_id,
+            }
+        )
+
+    buzz_queue = []
+    for index, player_id in enumerate(lobby["buzz_order"]):
+        player = lobby["players"].get(player_id)
+        if not player:
+            continue
+        buzz_queue.append(
+            {
+                "id": player_id,
+                "name": player["name"],
+                "position": index + 1,
+            }
+        )
+
+    response = {
+        "code": code,
+        "locked": lobby["locked"],
+        "host": {"name": lobby["host_name"]},
+        "players": players,
+        "buzz_queue": buzz_queue,
+        "buzz_open": not lobby["locked"],
+    }
+
+    if role == "player":
+        position = next(
+            (entry["position"] for entry in buzz_queue if entry["id"] == session_id),
+            None,
+        )
+        response["you"] = {
+            "id": session_id,
+            "name": session.get("buzzer_name"),
+            "position": position,
+            "can_buzz": not lobby["locked"] and position is None,
+        }
+    else:
+        response["you"] = {"role": "host", "name": session.get("buzzer_name")}
+
+    return jsonify(response)
+
+
+@bp.route("/buzzer/api/lobbies/<code>/buzz", methods=["POST"])
+@login_required
+def buzzer_buzz(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "player" or session.get("buzzer_code") != code:
+        return jsonify({"error": "not-in-lobby"}), 403
+
+    player_id = session.get("buzzer_id")
+    player = lobby["players"].get(player_id)
+    if not player:
+        _clear_buzzer_session()
+        return jsonify({"error": "not-in-lobby"}), 403
+
+    if lobby["locked"]:
+        return jsonify({"error": "locked"}), 400
+
+    if player_id in lobby["buzz_order"]:
+        position = lobby["buzz_order"].index(player_id) + 1
+        return jsonify({"status": "already", "position": position})
+
+    now = time.time()
+    lobby["buzz_order"].append(player_id)
+    player["buzzed_at"] = now
+    player["last_seen"] = now
+    lobby["updated_at"] = now
+    if len(lobby["buzz_order"]) == 1:
+        lobby["locked"] = True
+
+    return jsonify({"status": "ok", "position": len(lobby["buzz_order"])})
+
+
+@bp.route("/buzzer/api/lobbies/<code>/reset", methods=["POST"])
+@login_required
+def buzzer_reset(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "host" or session.get("buzzer_id") != lobby["host_id"]:
+        return jsonify({"error": "forbidden"}), 403
+
+    lobby["buzz_order"].clear()
+    lobby["locked"] = False
+    now = time.time()
+    for player in lobby["players"].values():
+        player["buzzed_at"] = None
+    lobby["updated_at"] = now
+
+    return jsonify({"status": "ok"})
+
+
+@bp.route("/buzzer/api/lobbies/<code>/lock", methods=["POST"])
+@login_required
+def buzzer_lock(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "host" or session.get("buzzer_id") != lobby["host_id"]:
+        return jsonify({"error": "forbidden"}), 403
+
+    lobby["locked"] = not lobby["locked"]
+    lobby["updated_at"] = time.time()
+
+    return jsonify({"status": "ok", "locked": lobby["locked"]})
+
+
+@bp.route("/buzzer/api/lobbies/<code>/close", methods=["POST"])
+@login_required
+def buzzer_close(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "host" or session.get("buzzer_id") != lobby["host_id"]:
+        return jsonify({"error": "forbidden"}), 403
+
+    del LOBBIES[code]
+    _clear_buzzer_session()
+
+    return jsonify({"status": "ok"})
+
+
+@bp.route("/buzzer/api/lobbies/<code>/leave", methods=["POST"])
+@login_required
+def buzzer_leave(code):
+    code = code.upper()
+
+    if session.get("buzzer_role") != "player" or session.get("buzzer_code") != code:
+        _clear_buzzer_session()
+        return jsonify({"status": "ok"})
+
+    player_id = session.get("buzzer_id")
+    _remove_player_from_lobby(code, player_id)
+    _clear_buzzer_session()
+
+    return jsonify({"status": "ok"})
 
 
 @bp.route("/", methods=["GET", "POST"])

--- a/app/static/buzzer.js
+++ b/app/static/buzzer.js
@@ -1,0 +1,300 @@
+(() => {
+  const root = document.querySelector('[data-buzzer]');
+  if (!root) {
+    return;
+  }
+
+  const role = root.dataset.role;
+  const stateUrl = root.dataset.stateUrl;
+  const lockUrl = root.dataset.lockUrl;
+  const resetUrl = root.dataset.resetUrl;
+  const closeUrl = root.dataset.closeUrl;
+  const buzzUrl = root.dataset.buzzUrl;
+  const leaveUrl = root.dataset.leaveUrl;
+  const leaveRedirect = root.dataset.leaveRedirect;
+
+  const lockIndicator = root.querySelector('[data-lock-indicator]');
+  const queueEl = root.querySelector('[data-queue]');
+  const rosterEl = root.querySelector('[data-roster]');
+  const emptyQueueEl = root.querySelector('[data-empty-queue]');
+  const emptyRosterEl = root.querySelector('[data-empty-roster]');
+  const statusEl = root.querySelector('[data-status]');
+  const lockButton = root.querySelector('[data-lock-button]');
+  const resetButton = root.querySelector('[data-reset-button]');
+  const closeButton = root.querySelector('[data-close-button]');
+  const buzzButton = root.querySelector('[data-buzz-button]');
+  const leaveButton = root.querySelector('[data-leave-button]');
+
+  let pollTimer = null;
+  let fetching = false;
+
+  const safeRedirect = () => {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+    if (leaveRedirect) {
+      window.location.href = leaveRedirect;
+    }
+  };
+
+  const updateVisibility = (el, shouldShow) => {
+    if (!el) {
+      return;
+    }
+    el.style.display = shouldShow ? '' : 'none';
+  };
+
+  const postJson = async (url) => {
+    if (!url) {
+      return null;
+    }
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.status === 404) {
+        safeRedirect();
+        return null;
+      }
+
+      if (response.status === 403) {
+        safeRedirect();
+        return null;
+      }
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const contentLength = response.headers.get('content-length');
+      if (contentLength === '0') {
+        return null;
+      }
+
+      const text = await response.text();
+      if (!text) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(text);
+      } catch (err) {
+        return null;
+      }
+    } catch (error) {
+      console.error('Unable to send request', error);
+      return null;
+    }
+  };
+
+  const applyQueue = (queue = []) => {
+    if (!queueEl) {
+      return;
+    }
+    queueEl.innerHTML = '';
+    if (!queue.length) {
+      updateVisibility(queueEl, false);
+      updateVisibility(emptyQueueEl, true);
+      return;
+    }
+
+    updateVisibility(queueEl, true);
+    updateVisibility(emptyQueueEl, false);
+
+    queue.forEach((entry) => {
+      const item = document.createElement('li');
+      const name = document.createElement('span');
+      name.textContent = `#${entry.position}`;
+      const label = document.createElement('strong');
+      label.textContent = entry.name;
+      item.appendChild(label);
+      item.appendChild(name);
+      queueEl.appendChild(item);
+    });
+  };
+
+  const applyRoster = (players = []) => {
+    if (!rosterEl) {
+      return;
+    }
+
+    rosterEl.innerHTML = '';
+    if (!players.length) {
+      updateVisibility(rosterEl, false);
+      updateVisibility(emptyRosterEl, true);
+      return;
+    }
+
+    updateVisibility(rosterEl, true);
+    updateVisibility(emptyRosterEl, false);
+
+    players.forEach((player) => {
+      const item = document.createElement('li');
+      item.textContent = player.name;
+      if (player.position) {
+        const badge = document.createElement('span');
+        badge.textContent = `#${player.position}`;
+        item.appendChild(badge);
+      }
+      if (player.buzzed) {
+        item.classList.add('is-buzzed');
+      }
+      if (player.is_self) {
+        item.classList.add('is-self');
+      }
+      rosterEl.appendChild(item);
+    });
+  };
+
+  const applyState = (state) => {
+    if (!state) {
+      return;
+    }
+
+    root.classList.toggle('is-locked', Boolean(state.locked));
+
+    if (lockIndicator) {
+      lockIndicator.textContent = state.locked ? 'Buzzers locked' : 'Buzzers open';
+      lockIndicator.classList.toggle('status-pill--locked', Boolean(state.locked));
+    }
+
+    applyQueue(state.buzz_queue);
+    applyRoster(state.players);
+
+    if (role === 'player' && state.you) {
+      if (statusEl) {
+        if (typeof state.you.position === 'number') {
+          statusEl.textContent = state.you.position === 1
+            ? 'You rang in first!'
+            : `You are #${state.you.position} in the queue.`;
+        } else if (state.buzz_open) {
+          statusEl.textContent = 'Buzzers are open!';
+        } else if (state.buzz_queue && state.buzz_queue.length) {
+          const leader = state.buzz_queue[0];
+          statusEl.textContent = `${leader.name} buzzed in first.`;
+        } else {
+          statusEl.textContent = 'Waiting for buzzers to open…';
+        }
+      }
+
+      if (buzzButton) {
+        buzzButton.disabled = !state.you.can_buzz;
+        if (state.you.position) {
+          buzzButton.textContent = 'Buzzed';
+        } else {
+          buzzButton.textContent = 'Buzz in';
+        }
+      }
+    }
+
+    if (role === 'host') {
+      if (lockButton) {
+        lockButton.textContent = state.locked ? 'Unlock buzzers' : 'Lock buzzers';
+      }
+      if (resetButton) {
+        resetButton.disabled = !state.buzz_queue || !state.buzz_queue.length;
+      }
+    }
+  };
+
+  const fetchState = async () => {
+    if (!stateUrl || fetching) {
+      return;
+    }
+    fetching = true;
+    try {
+      const response = await fetch(stateUrl, {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+
+      if (response.status === 404 || response.status === 403) {
+        safeRedirect();
+        return;
+      }
+
+      if (!response.ok) {
+        return;
+      }
+
+      const data = await response.json();
+      applyState(data);
+    } catch (error) {
+      console.error('Unable to refresh lobby state', error);
+    } finally {
+      fetching = false;
+    }
+  };
+
+  if (lockButton && lockUrl) {
+    lockButton.addEventListener('click', async () => {
+      lockButton.disabled = true;
+      await postJson(lockUrl);
+      lockButton.disabled = false;
+      fetchState();
+    });
+  }
+
+  if (resetButton && resetUrl) {
+    resetButton.addEventListener('click', async () => {
+      resetButton.disabled = true;
+      await postJson(resetUrl);
+      resetButton.disabled = false;
+      fetchState();
+    });
+  }
+
+  if (closeButton && closeUrl) {
+    closeButton.addEventListener('click', async () => {
+      closeButton.disabled = true;
+      await postJson(closeUrl);
+      safeRedirect();
+    });
+  }
+
+  if (buzzButton && buzzUrl) {
+    buzzButton.addEventListener('click', async () => {
+      if (buzzButton.disabled) {
+        return;
+      }
+      buzzButton.disabled = true;
+      await postJson(buzzUrl);
+      fetchState();
+    });
+  }
+
+  if (leaveButton && leaveUrl) {
+    leaveButton.addEventListener('click', async () => {
+      leaveButton.disabled = true;
+      await postJson(leaveUrl);
+      safeRedirect();
+    });
+  }
+
+  const startPolling = () => {
+    fetchState();
+    pollTimer = setInterval(fetchState, 1500);
+  };
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+      }
+    } else if (!pollTimer) {
+      startPolling();
+    }
+  });
+
+  startPolling();
+})();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -190,6 +190,18 @@ input:focus {
   border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
+.placeholder-link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.2s ease, transform 0.15s ease;
+}
+
+.placeholder-link:hover {
+  border-color: rgba(255, 255, 255, 0.32);
+  transform: translateY(-2px);
+}
+
 .placeholder h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;
@@ -201,6 +213,170 @@ input:focus {
   color: var(--text-muted);
 }
 
+.buzzer-card {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.buzzer-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.buzzer-panel {
+  background: rgba(10, 18, 38, 0.9);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.buzzer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: rgba(79, 196, 255, 0.18);
+  border: 1px solid rgba(79, 196, 255, 0.4);
+  color: #bde9ff;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.status-pill--muted {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.24);
+  color: #f5f6ff;
+}
+
+.status-pill--locked {
+  background: rgba(255, 107, 107, 0.18);
+  border-color: rgba(255, 107, 107, 0.45);
+  color: #ffb4b4;
+}
+
+.buzzer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn-tertiary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #f5f6ff;
+  border-radius: 999px;
+  padding: 0.85rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.btn-tertiary:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.buzzer-sections {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.buzzer-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.buzz-queue,
+.buzzer-roster {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.buzz-queue li,
+.buzzer-roster li {
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.buzz-queue li span,
+.buzzer-roster li span {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.buzzer-roster li.is-buzzed {
+  border-color: rgba(255, 183, 3, 0.55);
+  box-shadow: 0 0 12px rgba(255, 183, 3, 0.25);
+}
+
+.buzzer-roster li.is-self {
+  border-color: rgba(111, 123, 247, 0.6);
+}
+
+.buzzer-button {
+  width: 100%;
+  padding: clamp(1.2rem, 5vw, 2.5rem);
+  border-radius: 2rem;
+  border: none;
+  font-size: clamp(1.5rem, 5vw, 2.25rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #0b132b;
+  background: linear-gradient(135deg, #ffb703, #fb8500);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.buzzer-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 30px rgba(251, 133, 0, 0.35);
+  filter: brightness(1.05);
+}
+
+.buzzer-button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.4) brightness(0.85);
+  box-shadow: none;
+}
+
+.share-link {
+  display: inline-block;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  font-size: 0.9rem;
+  color: #f5f6ff;
+}
+
+.is-locked .buzzer-button {
+  filter: grayscale(0.5);
+}
+
 @media (max-width: 600px) {
   .card {
     padding: 1.75rem;
@@ -208,5 +384,10 @@ input:focus {
 
   .brand {
     font-size: 2.75rem;
+  }
+
+  .buzzer-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,5 +27,6 @@
       {% endwith %}
       {% block content %}{% endblock %}
     </main>
+    {% block extra_scripts %}{% endblock %}
   </body>
 </html>

--- a/app/templates/buzzer_host.html
+++ b/app/templates/buzzer_host.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Lobby {{ code }} · Panenka Live{% endblock %}
+{% block content %}
+<section
+  class="card buzzer-card"
+  data-buzzer
+  data-role="host"
+  data-state-url="{{ url_for('main.buzzer_state', code=code) }}"
+  data-lock-url="{{ url_for('main.buzzer_lock', code=code) }}"
+  data-reset-url="{{ url_for('main.buzzer_reset', code=code) }}"
+  data-close-url="{{ url_for('main.buzzer_close', code=code) }}"
+  data-leave-redirect="{{ url_for('main.buzzer_home') }}"
+>
+  <header class="buzzer-header">
+    <div>
+      <p class="helper-text">Hosting as {{ host_name }}</p>
+      <h2 class="card-title">Lobby {{ code }}</h2>
+    </div>
+    <span class="status-pill" data-lock-indicator>Buzzers open</span>
+  </header>
+  <p class="card-description">
+    Share the code <span class="status-pill status-pill--muted">{{ code }}</span> or send this link:
+    <code class="share-link">{{ share_url }}</code>
+  </p>
+  <div class="buzzer-actions">
+    <button class="btn-primary" type="button" data-lock-button>Lock buzzers</button>
+    <button class="btn-secondary" type="button" data-reset-button>Reset buzzers</button>
+    <button class="btn-tertiary" type="button" data-close-button>Close lobby</button>
+  </div>
+  <div class="buzzer-sections">
+    <section class="buzzer-section">
+      <h3>Buzz queue</h3>
+      <p class="helper-text" data-empty-queue>Waiting for the first buzz...</p>
+      <ol class="buzz-queue" data-queue></ol>
+    </section>
+    <section class="buzzer-section">
+      <h3>Players</h3>
+      <p class="helper-text" data-empty-roster>No players yet.</p>
+      <ul class="buzzer-roster" data-roster></ul>
+    </section>
+  </div>
+</section>
+{% endblock %}
+{% block extra_scripts %}
+  <script src="{{ url_for('static', filename='buzzer.js') }}" defer></script>
+{% endblock %}

--- a/app/templates/buzzer_landing.html
+++ b/app/templates/buzzer_landing.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Buzzer Lobby · Panenka Live{% endblock %}
+{% block content %}
+<section class="card buzzer-card">
+  <h2 class="card-title">Buzzer Lobby</h2>
+  <p class="card-description">Create a room for your trivia night or join an existing game to buzz in instantly.</p>
+  <div class="buzzer-grid">
+    <article class="buzzer-panel">
+      <h3>Host a lobby</h3>
+      <p class="helper-text">You'll appear as <strong>{{ default_name }}</strong>.</p>
+      <form class="form" method="post" action="{{ url_for('main.buzzer_create') }}">
+        <button class="btn-primary" type="submit">Create lobby</button>
+      </form>
+    </article>
+    <article class="buzzer-panel">
+      <h3>Join a lobby</h3>
+      <form class="form" method="post" action="{{ url_for('main.buzzer_join') }}">
+        <div class="field">
+          <label class="field-label" for="code">Lobby code</label>
+          <input id="code" name="code" type="text" inputmode="text" minlength="{{ lobby_code_length }}" maxlength="{{ lobby_code_length }}" pattern="[A-Za-z0-9]{4}" placeholder="ABCD" value="{{ requested_code }}" required>
+        </div>
+        <div class="field">
+          <label class="field-label" for="display_name">Display name</label>
+          <input id="display_name" name="display_name" type="text" maxlength="32" placeholder="Enter your name" value="{{ default_name }}" required>
+        </div>
+        <button class="btn-primary" type="submit">Join lobby</button>
+      </form>
+    </article>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/buzzer_player.html
+++ b/app/templates/buzzer_player.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}Lobby {{ code }} · Panenka Live{% endblock %}
+{% block content %}
+<section
+  class="card buzzer-card"
+  data-buzzer
+  data-role="player"
+  data-state-url="{{ url_for('main.buzzer_state', code=code) }}"
+  data-buzz-url="{{ url_for('main.buzzer_buzz', code=code) }}"
+  data-leave-url="{{ url_for('main.buzzer_leave', code=code) }}"
+  data-leave-redirect="{{ url_for('main.buzzer_home') }}"
+>
+  <header class="buzzer-header">
+    <div>
+      <p class="helper-text">Buzzing as {{ display_name }}</p>
+      <h2 class="card-title">Lobby {{ code }}</h2>
+    </div>
+    <span class="status-pill" data-lock-indicator>Waiting for host</span>
+  </header>
+  <p class="card-description">Host: {{ host_name }}</p>
+  <button class="buzzer-button" type="button" data-buzz-button>Buzz in</button>
+  <p class="helper-text" data-status>Waiting for buzzers to open…</p>
+  <section class="buzzer-section">
+    <h3>Buzz queue</h3>
+    <p class="helper-text" data-empty-queue>Queue updates in real time.</p>
+    <ol class="buzz-queue" data-queue></ol>
+  </section>
+  <section class="buzzer-section">
+    <h3>Players</h3>
+    <p class="helper-text" data-empty-roster>No one else is here yet.</p>
+    <ul class="buzzer-roster" data-roster></ul>
+  </section>
+  <button class="btn-tertiary" type="button" data-leave-button>Leave lobby</button>
+</section>
+{% endblock %}
+{% block extra_scripts %}
+  <script src="{{ url_for('static', filename='buzzer.js') }}" defer></script>
+{% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -12,10 +12,10 @@
   </h2>
   <p class="card-description">You're in! We'll soon add buzzers, scoreboards, and more interactive tools.</p>
   <div class="placeholder-grid">
-    <article class="placeholder">
+    <a class="placeholder placeholder-link" href="{{ url_for('main.buzzer_home') }}">
       <h3>Buzzer Pad</h3>
-      <p>Coming soon: a responsive buzzer so you can ring in instantly.</p>
-    </article>
+      <p>Host a lobby or buzz in with live updates.</p>
+    </a>
     <article class="placeholder">
       <h3>Game Lobby</h3>
       <p>Stay tuned for host-managed rooms and quick joining via shareable codes.</p>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the application package is importable during pytest collection.
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_buzzer.py
+++ b/tests/test_buzzer.py
@@ -1,0 +1,80 @@
+import unittest
+
+from app import create_app
+from app.routes import LOBBIES, LOBBY_CODE_LENGTH
+
+
+LOGIN_CODE = "888"
+PASSWORD_CODE = "6969"
+
+
+class BuzzerFlowTestCase(unittest.TestCase):
+    def setUp(self):
+        LOBBIES.clear()
+        self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+        with self.client:
+            self.client.post(
+                "/",
+                data={"login": LOGIN_CODE, "password": PASSWORD_CODE},
+            )
+
+    def tearDown(self):
+        LOBBIES.clear()
+
+    def test_host_can_create_lobby(self):
+        response = self.client.post("/buzzer/create", follow_redirects=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/buzzer/host/", response.headers["Location"])
+
+        code = response.headers["Location"].rstrip("/").rsplit("/", 1)[-1]
+        self.assertEqual(len(code), LOBBY_CODE_LENGTH)
+        self.assertIn(code, LOBBIES)
+
+        with self.client:
+            state_response = self.client.get(f"/buzzer/api/lobbies/{code}/state")
+            self.assertEqual(state_response.status_code, 200)
+            payload = state_response.get_json()
+            self.assertEqual(payload["code"], code)
+            self.assertTrue(payload["buzz_open"])
+
+    def test_player_can_join_and_buzz(self):
+        response = self.client.post("/buzzer/create", follow_redirects=False)
+        code = response.headers["Location"].rstrip("/").rsplit("/", 1)[-1]
+
+        player_app = create_app()
+        player_app.config["TESTING"] = True
+        player_client = player_app.test_client()
+
+        with player_client:
+            player_client.post(
+                "/",
+                data={"login": LOGIN_CODE, "password": PASSWORD_CODE},
+            )
+            join_response = player_client.post(
+                "/buzzer/join",
+                data={"code": code, "display_name": "Player One"},
+                follow_redirects=False,
+            )
+            self.assertEqual(join_response.status_code, 302)
+            lobby = LOBBIES[code]
+            self.assertEqual(len(lobby["players"]), 1)
+
+            buzz_response = player_client.post(f"/buzzer/api/lobbies/{code}/buzz")
+            self.assertEqual(buzz_response.status_code, 200)
+            payload = buzz_response.get_json()
+            self.assertIn(payload["status"], {"ok", "already"})
+            self.assertEqual(lobby["buzz_order"], list(lobby["players"].keys()))
+
+        with self.client:
+            reset_response = self.client.post(f"/buzzer/api/lobbies/{code}/reset")
+            self.assertEqual(reset_response.status_code, 200)
+            state_response = self.client.get(f"/buzzer/api/lobbies/{code}/state")
+            state_payload = state_response.get_json()
+            self.assertEqual(state_payload["buzz_queue"], [])
+            self.assertTrue(state_payload["buzz_open"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add lobby management helpers and endpoints to create, join, and control interactive buzzer rooms
- build host and player templates with supporting styles and JavaScript for live queue updates
- add automated lobby flow tests and ensure the app package is importable during pytest collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7407213c883238034c0678c3ac43b