### PR TITLE
Improve buzzer session stability

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -41,7 +41,10 @@ DEFAULT_FALLBACK_USERS = [
 LOBBY_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 LOBBY_CODE_LENGTH = 4
 LOBBY_EXPIRATION_SECONDS = 60 * 60
-PLAYER_EXPIRATION_SECONDS = 45
+# Players might briefly pause polling when their browser tab is hidden.
+# Give them a generous window before considering the session stale so they
+# are not unexpectedly kicked out of a lobby.
+PLAYER_EXPIRATION_SECONDS = 180
 
 
 LOBBIES = {}

--- a/app/static/buzzer.js
+++ b/app/static/buzzer.js
@@ -26,13 +26,11 @@
   const leaveButton = root.querySelector('[data-leave-button]');
 
   let pollTimer = null;
+  let pollInterval = 1500;
   let fetching = false;
 
   const safeRedirect = () => {
-    if (pollTimer) {
-      clearInterval(pollTimer);
-      pollTimer = null;
-    }
+    clearPollingTimer();
     if (leaveRedirect) {
       window.location.href = leaveRedirect;
     }
@@ -280,19 +278,31 @@
     });
   }
 
-  const startPolling = () => {
-    fetchState();
-    pollTimer = setInterval(fetchState, 1500);
+  const clearPollingTimer = () => {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  const startPolling = (interval = pollInterval, { immediate = true } = {}) => {
+    pollInterval = interval;
+    clearPollingTimer();
+    if (immediate) {
+      fetchState();
+    }
+    pollTimer = setInterval(fetchState, pollInterval);
+  };
+
+  const setPollingInterval = (interval, options) => {
+    startPolling(interval, options);
   };
 
   document.addEventListener('visibilitychange', () => {
     if (document.hidden) {
-      if (pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = null;
-      }
-    } else if (!pollTimer) {
-      startPolling();
+      setPollingInterval(8000, { immediate: true });
+    } else {
+      setPollingInterval(1500, { immediate: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- extend the server-side player expiration window so hidden browser tabs are not removed immediately
- adjust the buzzer client polling logic to slow down instead of stopping when the tab is hidden, keeping the lobby state in sync

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d746a3037c832382b50dc321f5e5dd