### PR TITLE
Update buzzer button styling and states

### DIFF
--- a/app/static/buzzer.js
+++ b/app/static/buzzer.js
@@ -182,11 +182,23 @@
       }
 
       if (buzzButton) {
+        const position = typeof state.you.position === 'number' ? state.you.position : null;
+        const isLocked = Boolean(state.locked);
+        const buttonState = isLocked
+          ? 'locked'
+          : position
+            ? 'queued'
+            : 'ready';
+
         buzzButton.disabled = !state.you.can_buzz;
-        if (state.you.position) {
-          buzzButton.textContent = 'Buzzed';
+        buzzButton.dataset.state = buttonState;
+
+        if (isLocked) {
+          buzzButton.textContent = 'LOCKED';
+        } else if (position) {
+          buzzButton.textContent = `#${position}`;
         } else {
-          buzzButton.textContent = 'Buzz in';
+          buzzButton.textContent = 'BUZZ!';
         }
       }
     }

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -338,30 +338,45 @@ input:focus {
 }
 
 .buzzer-button {
-  width: 100%;
-  padding: clamp(1.2rem, 5vw, 2.5rem);
-  border-radius: 2rem;
+  width: clamp(9rem, 55vw, 15rem);
+  aspect-ratio: 1 / 1;
+  margin: clamp(1.5rem, 6vw, 2.75rem) auto;
+  border-radius: 50%;
   border: none;
-  font-size: clamp(1.5rem, 5vw, 2.25rem);
+  display: grid;
+  place-items: center;
+  font-size: clamp(1.75rem, 6vw, 2.5rem);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: #0b132b;
-  background: linear-gradient(135deg, #ffb703, #fb8500);
+  letter-spacing: 0.08em;
+  color: #f4fff7;
+  background: #0d6b34;
   cursor: pointer;
+  box-shadow: 0 18px 32px rgba(13, 107, 52, 0.35);
   transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
-.buzzer-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 30px rgba(251, 133, 0, 0.35);
+.buzzer-button[data-state='queued'] {
+  background: #0a4c25;
+  box-shadow: 0 18px 32px rgba(10, 76, 37, 0.4);
+}
+
+.buzzer-button[data-state='locked'] {
+  background: #b48800;
+  color: #221600;
+  box-shadow: 0 18px 32px rgba(180, 136, 0, 0.4);
+}
+
+.buzzer-button:not([data-state='locked']):not(:disabled):hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 36px rgba(13, 107, 52, 0.45);
   filter: brightness(1.05);
 }
 
 .buzzer-button:disabled {
   cursor: not-allowed;
-  filter: grayscale(0.4) brightness(0.85);
-  box-shadow: none;
+  transform: none;
+  filter: none;
 }
 
 .share-link {
@@ -371,10 +386,6 @@ input:focus {
   border-radius: 0.75rem;
   font-size: 0.9rem;
   color: #f5f6ff;
-}
-
-.is-locked .buzzer-button {
-  filter: grayscale(0.5);
 }
 
 @media (max-width: 600px) {

--- a/app/templates/buzzer_player.html
+++ b/app/templates/buzzer_player.html
@@ -18,7 +18,7 @@
     <span class="status-pill" data-lock-indicator>Waiting for host</span>
   </header>
   <p class="card-description">Host: {{ host_name }}</p>
-  <button class="buzzer-button" type="button" data-buzz-button>Buzz in</button>
+  <button class="buzzer-button" type="button" data-buzz-button data-state="ready">BUZZ!</button>
   <p class="helper-text" data-status>Waiting for buzzers to open…</p>
   <section class="buzzer-section">
     <h3>Buzz queue</h3>


### PR DESCRIPTION
## Summary
- restyle the player buzzer button to use a circular dark-green base with queued and locked color variants
- drive the button text and state via updated client logic so it reflects BUZZ!, queue position numbers, or LOCKED as appropriate
- default the player template to the new BUZZ! label and state attribute

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d0e7de1083239b43ae0f59387332