### PR TITLE
Allow players to queue buzzes without auto-locking

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -615,9 +615,6 @@ def buzzer_buzz(code):
     player["buzzed_at"] = now
     player["last_seen"] = now
     lobby["updated_at"] = now
-    if len(lobby["buzz_order"]) == 1:
-        lobby["locked"] = True
-
     lobby_store.save_lobby(lobby)
 
     return jsonify({"status": "ok", "position": len(lobby["buzz_order"])})

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -325,12 +325,23 @@ input:focus {
 .buzz-queue li span,
 .buzzer-roster li span {
   font-weight: 600;
+}
+
+.buzz-queue li span {
+  color: var(--error);
+}
+
+.buzzer-roster li span {
   color: var(--accent);
 }
 
+.buzzer-roster li.is-buzzed span {
+  color: var(--error);
+}
+
 .buzzer-roster li.is-buzzed {
-  border-color: rgba(255, 183, 3, 0.55);
-  box-shadow: 0 0 12px rgba(255, 183, 3, 0.25);
+  border-color: rgba(255, 107, 107, 0.75);
+  box-shadow: 0 0 12px rgba(255, 107, 107, 0.35);
 }
 
 .buzzer-roster li.is-self {
@@ -357,8 +368,8 @@ input:focus {
 }
 
 .buzzer-button[data-state='queued'] {
-  background: #0a4c25;
-  box-shadow: 0 18px 32px rgba(10, 76, 37, 0.4);
+  background: var(--error);
+  box-shadow: 0 18px 32px rgba(255, 107, 107, 0.4);
 }
 
 .buzzer-button[data-state='locked'] {


### PR DESCRIPTION
## Summary
- keep the lobby open after the first buzz so additional players can join the queue
- refresh the buzzer UI to show queued players and buttons with a red state for clarity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d783734c8323801924088f2ee5b7