### PR TITLE
Allow players to buzz using the spacebar

### DIFF
--- a/app/static/buzzer.js
+++ b/app/static/buzzer.js
@@ -271,15 +271,32 @@
     });
   }
 
+  const triggerBuzz = async () => {
+    if (!buzzButton || !buzzUrl || buzzButton.disabled) {
+      return;
+    }
+    buzzButton.disabled = true;
+    await postJson(buzzUrl);
+    fetchState();
+  };
+
   if (buzzButton && buzzUrl) {
-    buzzButton.addEventListener('click', async () => {
-      if (buzzButton.disabled) {
-        return;
-      }
-      buzzButton.disabled = true;
-      await postJson(buzzUrl);
-      fetchState();
-    });
+    buzzButton.addEventListener('click', triggerBuzz);
+
+    if (role === 'player') {
+      document.addEventListener('keydown', (event) => {
+        const isSpace = event.code === 'Space' || event.key === ' ' || event.key === 'Spacebar';
+        const isTypingTarget = ['INPUT', 'TEXTAREA', 'SELECT'].includes(event.target.tagName)
+          || event.target.isContentEditable;
+
+        if (!isSpace || isTypingTarget) {
+          return;
+        }
+
+        event.preventDefault();
+        triggerBuzz();
+      });
+    }
   }
 
   if (leaveButton && leaveUrl) {


### PR DESCRIPTION
## Summary
- enable players to trigger the buzz action by pressing the spacebar
- reuse the click handler logic so keyboard input follows the same flow as button clicks
- avoid triggering the buzz when typing in input fields or editable elements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d981e1488323a70927e2212625b6