### PR TITLE
Add game lobby portal for hosting and joining lobbies

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -362,6 +362,53 @@ def buzzer_home():
     )
 
 
+@bp.route("/game-lobby")
+@login_required
+def game_lobby():
+    _expire_stale_lobbies()
+
+    requested_code = request.args.get("code", "").strip().upper()
+    code = session.get("buzzer_code")
+    role = session.get("buzzer_role")
+    session_id = session.get("buzzer_id")
+
+    host_lobby = None
+    player_lobby = None
+
+    if role == "host" and code:
+        lobby = lobby_store.get_lobby(code)
+        if lobby and lobby.get("host_id") == session_id:
+            host_lobby = {
+                "code": code,
+                "host_name": lobby["host_name"],
+                "share_url": url_for("main.buzzer_home", _external=True, code=code),
+                "manage_url": url_for(
+                    "main.buzzer_host", _external=True, code=code, token=lobby["host_token"]
+                ),
+                "resume_url": url_for("main.buzzer_host", code=code),
+                "player_count": len(lobby.get("players", {})),
+            }
+    elif role == "player" and code:
+        lobby = lobby_store.get_lobby(code)
+        if lobby and session_id in lobby["players"]:
+            player = lobby["players"].get(session_id, {})
+            player_lobby = {
+                "code": code,
+                "host_name": lobby["host_name"],
+                "display_name": player.get("name") or session.get("buzzer_name"),
+                "resume_url": url_for("main.buzzer_player", code=code),
+            }
+
+    return render_template(
+        "game_lobby.html",
+        default_name=_current_display_name(),
+        requested_code=requested_code,
+        lobby_code_length=LOBBY_CODE_LENGTH,
+        host_lobby=host_lobby,
+        player_lobby=player_lobby,
+    )
+
+
 @bp.route("/buzzer/create", methods=["POST"])
 @login_required
 def buzzer_create():

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -16,10 +16,10 @@
       <h3>Buzzer Pad</h3>
       <p>Host a lobby or buzz in with live updates.</p>
     </a>
-    <article class="placeholder">
+    <a class="placeholder placeholder-link" href="{{ url_for('main.game_lobby') }}">
       <h3>Game Lobby</h3>
-      <p>Stay tuned for host-managed rooms and quick joining via shareable codes.</p>
-    </article>
+      <p>Host-managed rooms with quick joining via shareable codes.</p>
+    </a>
     <article class="placeholder">
       <h3>Scoreboard</h3>
       <p>Track rankings and streaks once gameplay features are enabled.</p>

--- a/app/templates/game_lobby.html
+++ b/app/templates/game_lobby.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% block title %}Game Lobby · Panenka Live{% endblock %}
+{% block content %}
+<section class="card buzzer-card">
+  <h2 class="card-title">Game Lobby</h2>
+  <p class="card-description">Host-managed rooms with quick shareable codes for your trivia nights.</p>
+
+  {% if host_lobby %}
+    <article class="buzzer-panel">
+      <h3>You're hosting</h3>
+      <p class="helper-text">
+        Share the lobby code <span class="status-pill status-pill--muted">{{ host_lobby.code }}</span>
+        or send this link:
+        <code class="share-link">{{ host_lobby.share_url }}</code>
+      </p>
+      <p class="helper-text">
+        Bookmark your host controls:
+        <code class="share-link">{{ host_lobby.manage_url }}</code>
+      </p>
+      <p class="helper-text">
+        {% if host_lobby.player_count %}
+          {{ host_lobby.player_count }} player{% if host_lobby.player_count != 1 %}s{% endif %} connected.
+        {% else %}
+          No players have joined yet.
+        {% endif %}
+      </p>
+      <a class="btn-primary" href="{{ host_lobby.resume_url }}">Open host view</a>
+    </article>
+  {% elif player_lobby %}
+    <article class="buzzer-panel">
+      <h3>You're in a lobby</h3>
+      <p class="helper-text">
+        Buzzing as <strong>{{ player_lobby.display_name }}</strong> in lobby
+        <span class="status-pill status-pill--muted">{{ player_lobby.code }}</span> hosted by {{ player_lobby.host_name }}.
+      </p>
+      <a class="btn-primary" href="{{ player_lobby.resume_url }}">Rejoin lobby</a>
+    </article>
+  {% endif %}
+
+  <div class="buzzer-grid">
+    <article class="buzzer-panel">
+      <h3>Host a lobby</h3>
+      <p class="helper-text">You'll appear as <strong>{{ default_name }}</strong>.</p>
+      <form class="form" method="post" action="{{ url_for('main.buzzer_create') }}">
+        <button class="btn-primary" type="submit">Create lobby</button>
+      </form>
+    </article>
+    <article class="buzzer-panel">
+      <h3>Join a lobby</h3>
+      <form class="form" method="post" action="{{ url_for('main.buzzer_join') }}">
+        <div class="field">
+          <label class="field-label" for="code">Lobby code</label>
+          <input
+            id="code"
+            name="code"
+            type="text"
+            inputmode="text"
+            minlength="{{ lobby_code_length }}"
+            maxlength="{{ lobby_code_length }}"
+            pattern="[A-Za-z0-9]{4}"
+            placeholder="ABCD"
+            value="{{ requested_code }}"
+            required
+          >
+        </div>
+        <div class="field">
+          <label class="field-label" for="display_name">Display name</label>
+          <input
+            id="display_name"
+            name="display_name"
+            type="text"
+            maxlength="32"
+            placeholder="Enter your name"
+            value="{{ default_name }}"
+            required
+          >
+        </div>
+        <button class="btn-primary" type="submit">Join lobby</button>
+      </form>
+    </article>
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_game_lobby.py
+++ b/tests/test_game_lobby.py
@@ -1,0 +1,66 @@
+import unittest
+
+from app import create_app
+from app.lobby_store import lobby_store
+
+
+LOGIN_CODE = "888"
+PASSWORD_CODE = "6969"
+
+
+class GameLobbyViewTestCase(unittest.TestCase):
+    def setUp(self):
+        lobby_store.clear_all()
+        self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+        with self.client:
+            self.client.post("/", data={"login": LOGIN_CODE, "password": PASSWORD_CODE})
+
+    def tearDown(self):
+        lobby_store.clear_all()
+
+    def test_game_lobby_renders_host_and_join_forms(self):
+        response = self.client.get("/game-lobby")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Host a lobby", response.data)
+        self.assertIn(b"Join a lobby", response.data)
+        self.assertIn(b"name=\"code\"", response.data)
+
+    def test_game_lobby_shows_host_summary_when_active(self):
+        create_response = self.client.post("/buzzer/create", follow_redirects=False)
+        self.assertEqual(create_response.status_code, 302)
+
+        response = self.client.get("/game-lobby")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"You're hosting", response.data)
+        self.assertIn(b"Open host view", response.data)
+
+    def test_game_lobby_shows_player_summary(self):
+        host_response = self.client.post("/buzzer/create", follow_redirects=False)
+        host_code = host_response.headers["Location"].rstrip("/").rsplit("/", 1)[-1]
+
+        player_app = create_app()
+        player_app.config["TESTING"] = True
+        player_client = player_app.test_client()
+
+        with player_client:
+            player_client.post(
+                "/",
+                data={"login": LOGIN_CODE, "password": PASSWORD_CODE},
+            )
+            join_response = player_client.post(
+                "/buzzer/join",
+                data={"code": host_code, "display_name": "Player One"},
+                follow_redirects=False,
+            )
+            self.assertEqual(join_response.status_code, 302)
+
+            lobby_view = player_client.get("/game-lobby")
+            self.assertEqual(lobby_view.status_code, 200)
+            self.assertIn(b"You're in a lobby", lobby_view.data)
+            self.assertIn(host_code.encode(), lobby_view.data)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated game lobby page that surfaces host-managed room controls and join forms
- update the dashboard card to link into the lobby experience and reuse buzzer flows
- cover the new page with integration-style tests to keep the flows working

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7ddbbf7088323ba7bde3112171e20