### PR TITLE
Remove duplicate Buzzer Pad entry from dashboard

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -12,10 +12,6 @@
   </h2>
   <p class="card-description">You're in! We'll soon add buzzers, scoreboards, and more interactive tools.</p>
   <div class="placeholder-grid">
-    <a class="placeholder placeholder-link" href="{{ url_for('main.buzzer_home') }}">
-      <h3>Buzzer Pad</h3>
-      <p>Host a lobby or buzz in with live updates.</p>
-    </a>
     <a class="placeholder placeholder-link" href="{{ url_for('main.game_lobby') }}">
       <h3>Game Lobby</h3>
       <p>Host-managed rooms with quick joining via shareable codes.</p>


### PR DESCRIPTION
## Summary
- remove the duplicate Buzzer Pad placeholder link from the dashboard

## Testing
- python run.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e4ab97308323b6797a96d3369916