### PR TITLE
Restrict question value selection to preset buttons

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -92,6 +92,8 @@ def _expire_stale_players(lobby, now):
         lobby["buzz_order"] = [
             player_id for player_id in lobby["buzz_order"] if player_id not in removed_ids
         ]
+        if lobby.get("active_player_id") in removed_ids:
+            lobby["active_player_id"] = None
         lobby["updated_at"] = now
         return True
 
@@ -129,6 +131,8 @@ def _remove_player_from_lobby(code, player_id):
         lobby["buzz_order"] = [
             existing for existing in lobby["buzz_order"] if existing != player_id
         ]
+        if lobby.get("active_player_id") == player_id:
+            lobby["active_player_id"] = None
         lobby["updated_at"] = time.time()
         lobby_store.save_lobby(lobby)
 
@@ -432,6 +436,8 @@ def buzzer_create():
         "locked": False,
         "players": {},
         "buzz_order": [],
+        "question_value": 0,
+        "active_player_id": None,
     }
 
     lobby_store.save_lobby(lobby)
@@ -478,6 +484,7 @@ def buzzer_join():
         "joined_at": now,
         "last_seen": now,
         "buzzed_at": None,
+        "score": 0,
     }
     lobby["updated_at"] = now
 
@@ -577,6 +584,9 @@ def buzzer_state(code):
     if save_needed:
         lobby_store.save_lobby(lobby)
 
+    question_value = int(lobby.get("question_value", 0) or 0)
+    active_player_id = lobby.get("active_player_id")
+
     players = []
     for player_id, player in sorted(
         lobby["players"].items(), key=lambda item: item[1]["joined_at"]
@@ -586,13 +596,17 @@ def buzzer_state(code):
             if player_id in lobby["buzz_order"]
             else None
         )
+        score = int(player.get("score", 0) or 0)
+        is_active = player_id == active_player_id
         players.append(
             {
                 "id": player_id,
                 "name": player["name"],
                 "buzzed": position is not None,
                 "position": position,
+                "score": score,
                 "is_self": role == "player" and player_id == session_id,
+                "is_active": is_active,
             }
         )
 
@@ -606,8 +620,33 @@ def buzzer_state(code):
                 "id": player_id,
                 "name": player["name"],
                 "position": index + 1,
+                "is_active": player_id == active_player_id,
             }
         )
+
+    scoreboard_entries = []
+    for player_id, player in sorted(
+        lobby["players"].items(),
+        key=lambda item: (-int(item[1].get("score", 0) or 0), item[1]["joined_at"]),
+    ):
+        scoreboard_entries.append(
+            {
+                "id": player_id,
+                "name": player["name"],
+                "score": int(player.get("score", 0) or 0),
+                "is_active": player_id == active_player_id,
+            }
+        )
+
+    active_player = None
+    if active_player_id:
+        active_player = lobby["players"].get(active_player_id)
+        if active_player:
+            active_player = {
+                "id": active_player_id,
+                "name": active_player["name"],
+                "score": int(active_player.get("score", 0) or 0),
+            }
 
     response = {
         "code": code,
@@ -616,6 +655,9 @@ def buzzer_state(code):
         "players": players,
         "buzz_queue": buzz_queue,
         "buzz_open": not lobby["locked"],
+        "question_value": question_value,
+        "scoreboard": scoreboard_entries,
+        "active_player": active_player,
     }
 
     if role == "player":
@@ -628,6 +670,7 @@ def buzzer_state(code):
             "name": session.get("buzzer_name"),
             "position": position,
             "can_buzz": not lobby["locked"] and position is None,
+            "score": int(lobby["players"].get(session_id, {}).get("score", 0) or 0),
         }
     else:
         response["you"] = {"role": "host", "name": session.get("buzzer_name")}
@@ -667,6 +710,118 @@ def buzzer_buzz(code):
     return jsonify({"status": "ok", "position": len(lobby["buzz_order"])})
 
 
+@bp.route("/buzzer/api/lobbies/<code>/value", methods=["POST"])
+@login_required
+def buzzer_set_value(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "host" or session.get("buzzer_id") != lobby["host_id"]:
+        return jsonify({"error": "forbidden"}), 403
+
+    payload = request.get_json(silent=True) or {}
+    raw_value = payload.get("value")
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid-value"}), 400
+
+    allowed_values = {10, 20, 30, 40, 50}
+    if value not in allowed_values:
+        return jsonify({"error": "invalid-value"}), 400
+
+    lobby["question_value"] = value
+    lobby["updated_at"] = time.time()
+    lobby_store.save_lobby(lobby)
+
+    return jsonify({"status": "ok", "question_value": value})
+
+
+@bp.route("/buzzer/api/lobbies/<code>/confirm", methods=["POST"])
+@login_required
+def buzzer_confirm(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "host" or session.get("buzzer_id") != lobby["host_id"]:
+        return jsonify({"error": "forbidden"}), 403
+
+    payload = request.get_json(silent=True) or {}
+    player_id = payload.get("player_id")
+
+    if not player_id or player_id not in lobby["players"]:
+        return jsonify({"error": "invalid-player"}), 400
+
+    if player_id not in lobby["buzz_order"]:
+        return jsonify({"error": "player-not-in-queue"}), 400
+
+    now = time.time()
+    lobby["active_player_id"] = player_id
+    lobby["locked"] = True
+    player = lobby["players"][player_id]
+    player["last_seen"] = now
+    lobby["updated_at"] = now
+    lobby_store.save_lobby(lobby)
+
+    return jsonify(
+        {
+            "status": "ok",
+            "active_player": {
+                "id": player_id,
+                "name": player["name"],
+                "score": int(player.get("score", 0) or 0),
+            },
+        }
+    )
+
+
+@bp.route("/buzzer/api/lobbies/<code>/resolve", methods=["POST"])
+@login_required
+def buzzer_resolve(code):
+    code = code.upper()
+    lobby = _get_lobby_or_404(code)
+
+    if session.get("buzzer_role") != "host" or session.get("buzzer_id") != lobby["host_id"]:
+        return jsonify({"error": "forbidden"}), 403
+
+    active_player_id = lobby.get("active_player_id")
+    if not active_player_id or active_player_id not in lobby["players"]:
+        return jsonify({"error": "no-active-player"}), 400
+
+    payload = request.get_json(silent=True) or {}
+    action = (payload.get("action") or "").lower()
+    if action not in {"plus", "minus", "skip"}:
+        return jsonify({"error": "invalid-action"}), 400
+
+    player = lobby["players"][active_player_id]
+    current_score = int(player.get("score", 0) or 0)
+    question_value = int(lobby.get("question_value", 0) or 0)
+
+    if action == "plus":
+        current_score += question_value
+    elif action == "minus":
+        current_score -= question_value
+
+    player["score"] = current_score
+    now = time.time()
+    player["last_seen"] = now
+    lobby["active_player_id"] = None
+    lobby["buzz_order"].clear()
+    lobby["locked"] = False
+    for participant in lobby["players"].values():
+        participant["buzzed_at"] = None
+    lobby["updated_at"] = now
+    lobby_store.save_lobby(lobby)
+
+    return jsonify(
+        {
+            "status": "ok",
+            "action": action,
+            "score": current_score,
+        }
+    )
+
+
 @bp.route("/buzzer/api/lobbies/<code>/reset", methods=["POST"])
 @login_required
 def buzzer_reset(code):
@@ -678,6 +833,7 @@ def buzzer_reset(code):
 
     lobby["buzz_order"].clear()
     lobby["locked"] = False
+    lobby["active_player_id"] = None
     now = time.time()
     for player in lobby["players"].values():
         player["buzzed_at"] = None

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -301,6 +301,62 @@ input:focus {
   gap: 0.75rem;
 }
 
+.scoreboard {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.scoreboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.scoreboard__header h3 {
+  margin: 0;
+}
+
+.scoreboard__info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.scoreboard__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.scoreboard__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0.85rem;
+  border-radius: 0.85rem;
+  background: rgba(11, 19, 43, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.scoreboard__item.is-active {
+  border-color: rgba(255, 183, 3, 0.7);
+  box-shadow: 0 0 18px rgba(255, 183, 3, 0.25);
+}
+
+.scoreboard__item strong {
+  font-size: 1.1rem;
+  color: #fff;
+}
+
 .buzz-queue,
 .buzzer-roster {
   list-style: none;
@@ -335,6 +391,12 @@ input:focus {
   color: var(--accent);
 }
 
+.buzz-queue li.is-active,
+.buzzer-roster li.is-active {
+  border-color: rgba(255, 183, 3, 0.75);
+  box-shadow: 0 0 18px rgba(255, 183, 3, 0.25);
+}
+
 .buzzer-roster li.is-buzzed span {
   color: var(--error);
 }
@@ -346,6 +408,12 @@ input:focus {
 
 .buzzer-roster li.is-self {
   border-color: rgba(111, 123, 247, 0.6);
+}
+
+.player-score {
+  margin-left: auto;
+  font-weight: 700;
+  color: #fff;
 }
 
 .buzzer-button {
@@ -388,6 +456,110 @@ input:focus {
   cursor: not-allowed;
   transform: none;
   filter: none;
+}
+
+.answer-controls {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.answer-controls.is-disabled {
+  opacity: 0.6;
+}
+
+.answer-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn-score {
+  min-width: 4.5rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn-score:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.25);
+  box-shadow: 0 10px 25px rgba(255, 183, 3, 0.2);
+}
+
+.btn-score:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.value-picker {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.value-picker__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.value-button {
+  min-width: 3.5rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 0.85rem;
+  border: none;
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.value-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.24);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(80, 143, 255, 0.22);
+}
+
+.value-button.is-selected {
+  background: rgba(80, 143, 255, 0.85);
+  box-shadow: 0 12px 28px rgba(80, 143, 255, 0.35);
+}
+
+.value-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn-queue-confirm {
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.btn-queue-confirm:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+.btn-queue-confirm:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .share-link {

--- a/app/templates/buzzer_host.html
+++ b/app/templates/buzzer_host.html
@@ -9,6 +9,9 @@
   data-lock-url="{{ url_for('main.buzzer_lock', code=code) }}"
   data-reset-url="{{ url_for('main.buzzer_reset', code=code) }}"
   data-close-url="{{ url_for('main.buzzer_close', code=code) }}"
+  data-value-url="{{ url_for('main.buzzer_set_value', code=code) }}"
+  data-confirm-url="{{ url_for('main.buzzer_confirm', code=code) }}"
+  data-resolve-url="{{ url_for('main.buzzer_resolve', code=code) }}"
   data-leave-redirect="{{ url_for('main.buzzer_home') }}"
 >
   <header class="buzzer-header">
@@ -18,6 +21,17 @@
     </div>
     <span class="status-pill" data-lock-indicator>Buzzers open</span>
   </header>
+  <section class="scoreboard" data-scoreboard>
+    <header class="scoreboard__header">
+      <h3>Счёт</h3>
+      <div class="scoreboard__info">
+        <span>Номинал: <strong data-question-value>0</strong></span>
+        <span>Игрок: <strong data-active-player>—</strong></span>
+      </div>
+    </header>
+    <p class="helper-text" data-empty-scoreboard>Пока нет игроков.</p>
+    <ul class="scoreboard__list" data-score-list></ul>
+  </section>
   <div class="buzzer-share">
     <p class="card-description">
       Share the code <span class="status-pill status-pill--muted">{{ code }}</span> or send this link to players:
@@ -33,6 +47,29 @@
     <button class="btn-secondary" type="button" data-reset-button>Reset buzzers</button>
     <button class="btn-tertiary" type="button" data-close-button>Close lobby</button>
   </div>
+  <section class="buzzer-section">
+    <h3>Управление вопросом</h3>
+    <div class="value-picker" data-value-picker>
+      <p class="field-label">Номинал вопроса</p>
+      <div class="value-picker__buttons">
+        {% for value in (10, 20, 30, 40, 50) %}
+        <button
+          class="value-button"
+          type="button"
+          data-value-button="{{ value }}"
+        >{{ value }}</button>
+        {% endfor %}
+      </div>
+    </div>
+    <div class="answer-controls" data-answer-controls>
+      <p class="helper-text">Активный игрок: <strong data-active-player>—</strong></p>
+      <div class="answer-buttons">
+        <button class="btn-score" type="button" data-resolve-action="plus">+</button>
+        <button class="btn-score" type="button" data-resolve-action="minus">-</button>
+        <button class="btn-score" type="button" data-resolve-action="skip">SKIP</button>
+      </div>
+    </div>
+  </section>
   <div class="buzzer-sections">
     <section class="buzzer-section">
       <h3>Buzz queue</h3>

--- a/app/templates/buzzer_player.html
+++ b/app/templates/buzzer_player.html
@@ -18,6 +18,16 @@
     <span class="status-pill" data-lock-indicator>Waiting for host</span>
   </header>
   <p class="card-description">Host: {{ host_name }}</p>
+  <section class="scoreboard" data-scoreboard>
+    <header class="scoreboard__header">
+      <h3>Счёт</h3>
+      <div class="scoreboard__info">
+        <span>Номинал: <strong data-question-value>0</strong></span>
+      </div>
+    </header>
+    <p class="helper-text" data-empty-scoreboard>Пока нет игроков.</p>
+    <ul class="scoreboard__list" data-score-list></ul>
+  </section>
   <button class="buzzer-button" type="button" data-buzz-button data-state="ready">BUZZ!</button>
   <p class="helper-text" data-status>Waiting for buzzers to open…</p>
   <section class="buzzer-section">


### PR DESCRIPTION
## Summary
- replace the host question value input with preset buttons for 10, 20, 30, 40, and 50 points that highlight the active choice
- enforce the fixed question value options in the backend API and keep the UI buttons in sync as state updates arrive
- style the new value picker buttons to match the existing scoreboard controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e79608a08323aefb6c831953a997