### PR TITLE
Include player score in lobby listings

### DIFF
--- a/app/lobby_store.py
+++ b/app/lobby_store.py
@@ -453,6 +453,7 @@ class LobbyStore:
                 "joined_at": pdata["joined_at"],
                 "last_seen": pdata["last_seen"],
                 "buzzed_at": pdata.get("buzzed_at"),
+                "score": pdata["score"] if pdata.get("score") is not None else 0,
             }
 
         return list(lobbies.values())


### PR DESCRIPTION
## Summary
- ensure player scores are included when listing all lobbies so cached states stay consistent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d837dd11448323ac6c3b9c24c4b5ba