### PR TITLE
Document question importer usage and ignore SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ instance/
 .env
 auth.json
 .pytest_cache/
-app/lobbies.sqlite3
 .DS_Store
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ This repository contains a lightweight prototype inspired by [buzzin.live](https
 
 5. Open [http://localhost:5000](http://localhost:5000) in your browser and sign in with one of the configured accounts.
 
+## Importing project questions
+
+The trivia questions that power the in-game rounds are stored in the same SQLite
+database as the lobby data. Because binary database files are not tracked in
+the repository, you should populate your local database by running the importer
+script once after setting up the project:
+
+```bash
+python -m app.question_importer
+```
+
+The script downloads every season from the shared Google Sheet, normalizes the
+fields, and replaces the contents of the `questions` table. A fresh
+`app/lobbies.sqlite3` file will be created automatically if it does not already
+exist.
+
 ## Deploying to Heroku
 
 The project is configured for the [Heroku Python buildpack](https://devcenter.heroku.com/articles/getting-started-with-python). The steps below assume you already have the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) installed and are logged in.

--- a/app/question_importer.py
+++ b/app/question_importer.py
@@ -1,0 +1,228 @@
+import json
+import math
+import re
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterator, List, Optional, Tuple
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from .question_store import QuestionRecord, question_store
+
+SPREADSHEET_ID = "1JnSeNlpCq1XMz3mmROCOGCG5j0WpGNVlUsMeqNPqh-8"
+GVIZ_ENDPOINT = (
+    "https://docs.google.com/spreadsheets/d/" "{spreadsheet_id}/gviz/tq?tqx=out:json&sheet={sheet}"
+)
+USER_AGENT = "Mozilla/5.0 (compatible; PanenkaImporter/1.0)"
+
+DATE_CLEAN_RE = re.compile(r"^(?P<date>[^()]+?)(?:\s*\((?P<editor>[^()]+)\))?$")
+DATE_FORMATS = (
+    "%d.%m.%Y",
+    "%Y.%m.%d",
+    "%d.%m.%y",
+)
+
+
+@dataclass
+class ParsedQuestion:
+    season_number: int
+    row_number: int
+    played_at_raw: Optional[str]
+    played_at: Optional[str]
+    editor: Optional[str]
+    topic: Optional[str]
+    question_value: Optional[int]
+    author: Optional[str]
+    question_text: Optional[str]
+    answer_text: Optional[str]
+    taken_count: Optional[int]
+    not_taken_count: Optional[int]
+    comment: Optional[str]
+
+    def as_record(self) -> QuestionRecord:
+        return (
+            self.season_number,
+            self.row_number,
+            self.played_at_raw,
+            self.played_at,
+            self.editor,
+            self.topic,
+            self.question_value,
+            self.author,
+            self.question_text,
+            self.answer_text,
+            self.taken_count,
+            self.not_taken_count,
+            self.comment,
+        )
+
+
+def _fetch_season_data(season_number: int) -> Tuple[dict, List[dict]]:
+    sheet_name = quote(f"Сезон {season_number}")
+    url = GVIZ_ENDPOINT.format(spreadsheet_id=SPREADSHEET_ID, sheet=sheet_name)
+    request = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(request) as response:
+        payload = response.read().decode("utf-8")
+    prefix = "/*O_o*/\ngoogle.visualization.Query.setResponse("
+    suffix = ");"
+    if not payload.startswith(prefix) or not payload.endswith(suffix):
+        raise ValueError(f"Unexpected response format for season {season_number}")
+    data = json.loads(payload[len(prefix) : -len(suffix)])
+    table = data.get("table") or {}
+    rows = table.get("rows") or []
+    return data, rows
+
+
+def _parse_played_at(value: Optional[str]) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    if not value:
+        return None, None, None
+    value = value.strip()
+    if not value:
+        return None, None, None
+
+    editor: Optional[str] = None
+    match = DATE_CLEAN_RE.match(value)
+    date_part = value
+    if match:
+        date_part = match.group("date").strip()
+        editor_value = match.group("editor")
+        if editor_value:
+            editor = editor_value.strip() or None
+    date_part = date_part.replace("\\u00a0", " ").strip()
+    parsed_date: Optional[str] = None
+    normalized = date_part.replace("/", ".").replace("-", ".")
+    for fmt in DATE_FORMATS:
+        try:
+            parsed_date = datetime.strptime(normalized, fmt).date().isoformat()
+            break
+        except ValueError:
+            continue
+    return value, parsed_date, editor
+
+
+def _coerce_int(value: Optional[object]) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, (int,)):
+        return int(value)
+    if isinstance(value, float):
+        if math.isnan(value):
+            return None
+        return int(value)
+    if isinstance(value, str):
+        cleaned = value.strip().replace(" ", "")
+        if not cleaned:
+            return None
+        try:
+            return int(float(cleaned))
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_text(value: Optional[object]) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned if cleaned else None
+    return str(value)
+
+
+def _row_to_question(
+    season_number: int,
+    row_index: int,
+    header_rows: int,
+    row: dict,
+) -> Optional[ParsedQuestion]:
+    cells = row.get("c") or []
+
+    def cell_value(index: int) -> Optional[object]:
+        if index >= len(cells):
+            return None
+        cell = cells[index]
+        if not cell:
+            return None
+        return cell.get("v")
+
+    raw_date = _coerce_text(cell_value(0))
+    topic = _coerce_text(cell_value(1))
+    question_value = _coerce_int(cell_value(2))
+    author = _coerce_text(cell_value(3))
+    question_text = _coerce_text(cell_value(4))
+    answer_text = _coerce_text(cell_value(5))
+    taken_count = _coerce_int(cell_value(6))
+    not_taken_count = _coerce_int(cell_value(7))
+    comment = _coerce_text(cell_value(8))
+
+    if not any(
+        (
+            raw_date,
+            topic,
+            question_value,
+            author,
+            question_text,
+            answer_text,
+            taken_count,
+            not_taken_count,
+            comment,
+        )
+    ):
+        return None
+
+    played_at_raw_cleaned, parsed_date, editor = _parse_played_at(raw_date)
+    row_number = row_index + 1 + header_rows
+
+    return ParsedQuestion(
+        season_number=season_number,
+        row_number=row_number,
+        played_at_raw=played_at_raw_cleaned,
+        played_at=parsed_date,
+        editor=editor,
+        topic=topic,
+        question_value=question_value,
+        author=author,
+        question_text=question_text,
+        answer_text=answer_text,
+        taken_count=taken_count,
+        not_taken_count=not_taken_count,
+        comment=comment,
+    )
+
+
+def _iter_season_questions() -> Iterator[ParsedQuestion]:
+    seen_signatures = set()
+    season_number = 1
+    while True:
+        data, rows = _fetch_season_data(season_number)
+        signature = data.get("sig")
+        if signature in seen_signatures:
+            break
+        seen_signatures.add(signature)
+
+        table = data.get("table") or {}
+        header_rows = table.get("parsedNumHeaders") or 0
+        for row_index, row in enumerate(rows):
+            parsed = _row_to_question(season_number, row_index, header_rows, row)
+            if parsed:
+                yield parsed
+        season_number += 1
+
+
+def import_questions() -> int:
+    start = time.time()
+    questions = list(_iter_season_questions())
+    count = question_store.replace_all(q.as_record() for q in questions)
+    elapsed = time.time() - start
+    print(f"Imported {count} questions in {elapsed:.2f}s across {len({q.season_number for q in questions})} seasons.")
+    return count
+
+
+if __name__ == "__main__":
+    try:
+        import_questions()
+    except Exception as exc:  # pragma: no cover - manual execution helper
+        print(f"Failed to import questions: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/app/question_store.py
+++ b/app/question_store.py
@@ -1,0 +1,249 @@
+import os
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Optional, Tuple
+
+try:  # pragma: no cover - optional dependency for Postgres deployments
+    import psycopg2
+    import psycopg2.extras
+except ImportError:  # pragma: no cover - optional dependency for Postgres deployments
+    psycopg2 = None  # type: ignore[assignment]
+
+
+QuestionRecord = Tuple[
+    int,
+    int,
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[int],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[int],
+    Optional[int],
+    Optional[str],
+]
+
+
+class QuestionStore:
+    """Persist parsed questions in a SQLite or PostgreSQL database."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        db_url: Optional[str] = None
+        if db_path is None:
+            db_url = os.getenv("PANENKA_LOBBY_DB_URL") or os.getenv("DATABASE_URL")
+
+        if db_url:
+            if psycopg2 is None:
+                raise RuntimeError(
+                    "psycopg2 is required for PostgreSQL support but is not installed."
+                )
+            self._backend = "postgres"
+            self._db_url = self._normalize_postgres_url(db_url)
+            self._db_path = None
+        else:
+            configured_path = db_path or os.getenv("PANENKA_LOBBY_DB")
+            if configured_path:
+                base_path = Path(configured_path).expanduser()
+                if not base_path.is_absolute():
+                    base_path = (Path.cwd() / base_path).resolve()
+                else:
+                    base_path = base_path.resolve()
+            else:
+                base_path = Path(__file__).resolve().parent / "lobbies.sqlite3"
+
+            if not base_path.parent.exists():
+                base_path.parent.mkdir(parents=True, exist_ok=True)
+
+            self._db_path = str(base_path)
+            self._backend = "sqlite"
+        self._initialized = False
+        self._init_lock = threading.Lock()
+
+    @staticmethod
+    def _normalize_postgres_url(url: str) -> str:
+        if url.startswith("postgres://"):
+            return "postgresql://" + url[len("postgres://") :]
+        return url
+
+    def _connect_sqlite(self) -> sqlite3.Connection:
+        if self._db_path is None:
+            raise RuntimeError("SQLite backend not configured.")
+        conn = sqlite3.connect(
+            self._db_path,
+            timeout=30,
+            isolation_level="DEFERRED",
+            detect_types=sqlite3.PARSE_DECLTYPES,
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    @contextmanager
+    def _postgres_connection(self):  # pragma: no cover - exercised in production
+        if psycopg2 is None:
+            raise RuntimeError("psycopg2 must be installed for PostgreSQL support.")
+        if self._backend != "postgres":
+            raise RuntimeError("PostgreSQL connection requested for non-Postgres backend.")
+        conn = psycopg2.connect(
+            self._db_url,
+            cursor_factory=psycopg2.extras.RealDictCursor,
+        )
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _initialize(self) -> None:
+        if self._initialized:
+            return
+        with self._init_lock:
+            if self._initialized:
+                return
+            if self._backend == "sqlite":
+                self._initialize_sqlite()
+            else:
+                self._initialize_postgres()
+            self._initialized = True
+
+    def _initialize_sqlite(self) -> None:
+        with self._connect_sqlite() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS questions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    season_number INTEGER NOT NULL,
+                    row_number INTEGER NOT NULL,
+                    played_at_raw TEXT,
+                    played_at TEXT,
+                    editor TEXT,
+                    topic TEXT,
+                    question_value INTEGER,
+                    author TEXT,
+                    question_text TEXT,
+                    answer_text TEXT,
+                    taken_count INTEGER,
+                    not_taken_count INTEGER,
+                    comment TEXT,
+                    imported_at REAL NOT NULL,
+                    UNIQUE (season_number, row_number)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_questions_season
+                    ON questions (season_number)
+                """
+            )
+
+    def _initialize_postgres(self) -> None:  # pragma: no cover - exercised in production
+        with self._postgres_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS questions (
+                        id BIGSERIAL PRIMARY KEY,
+                        season_number INTEGER NOT NULL,
+                        row_number INTEGER NOT NULL,
+                        played_at_raw TEXT,
+                        played_at DATE,
+                        editor TEXT,
+                        topic TEXT,
+                        question_value INTEGER,
+                        author TEXT,
+                        question_text TEXT,
+                        answer_text TEXT,
+                        taken_count INTEGER,
+                        not_taken_count INTEGER,
+                        comment TEXT,
+                        imported_at DOUBLE PRECISION NOT NULL,
+                        UNIQUE (season_number, row_number)
+                    )
+                    """
+                )
+                cur.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_questions_season
+                        ON questions (season_number)
+                    """
+                )
+
+    def replace_all(self, records: Iterable[QuestionRecord]) -> int:
+        """Replace all stored questions with the provided records."""
+
+        self._initialize()
+        payloads = list(records)
+        if not payloads:
+            return 0
+        imported_at = time.time()
+
+        if self._backend == "sqlite":
+            with self._connect_sqlite() as conn:
+                conn.execute("DELETE FROM questions")
+                conn.executemany(
+                    """
+                    INSERT INTO questions (
+                        season_number,
+                        row_number,
+                        played_at_raw,
+                        played_at,
+                        editor,
+                        topic,
+                        question_value,
+                        author,
+                        question_text,
+                        answer_text,
+                        taken_count,
+                        not_taken_count,
+                        comment,
+                        imported_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [tuple(list(record) + [imported_at]) for record in payloads],
+                )
+        else:  # pragma: no cover - exercised in production
+            if psycopg2 is None:
+                raise RuntimeError("psycopg2 must be installed for PostgreSQL support.")
+            with self._postgres_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("DELETE FROM questions")
+                    psycopg2.extras.execute_batch(
+                        cur,
+                        """
+                        INSERT INTO questions (
+                            season_number,
+                            row_number,
+                            played_at_raw,
+                            played_at,
+                            editor,
+                            topic,
+                            question_value,
+                            author,
+                            question_text,
+                            answer_text,
+                            taken_count,
+                            not_taken_count,
+                            comment,
+                            imported_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        [
+                            record + (imported_at,)  # type: ignore[operator]
+                            for record in payloads
+                        ],
+                        page_size=200,
+                    )
+        return len(payloads)
+
+
+question_store = QuestionStore()


### PR DESCRIPTION
## Summary
- add a database-backed QuestionStore that can persist parsed trivia questions alongside existing lobby data
- build a Google Sheets importer that fetches every season, normalizes the fields, and bulk loads them into the questions table
- ignore generated SQLite database files and document how to regenerate the questions locally without committing binaries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d85303d7c08323a14238a5a0af5259