### PR TITLE
Add question explorer page with keyword and AI-assisted search

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -213,6 +213,98 @@ input:focus {
   color: var(--text-muted);
 }
 
+.question-card {
+  gap: 1.75rem;
+}
+
+.question-search {
+  display: grid;
+  gap: 1rem;
+}
+
+.question-search__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.checkbox-inline {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.checkbox input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--accent);
+}
+
+.input-number {
+  width: 5rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(12, 20, 43, 0.9);
+  color: inherit;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.input-number:focus {
+  outline: none;
+  border-color: var(--border-glow);
+  box-shadow: 0 0 0 3px rgba(111, 123, 247, 0.35);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(11, 19, 43, 0.75);
+}
+
+.question-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 760px;
+}
+
+.question-table thead th {
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.question-table td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  vertical-align: top;
+}
+
+.question-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.question-table__text {
+  white-space: pre-line;
+  line-height: 1.5;
+}
+
 .buzzer-card {
   display: grid;
   gap: 1.75rem;

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -16,6 +16,10 @@
       <h3>Game Lobby</h3>
       <p>Host-managed rooms with quick joining via shareable codes.</p>
     </a>
+    <a class="placeholder placeholder-link" href="{{ url_for('main.question_browser') }}">
+      <h3>Question Explorer</h3>
+      <p>Browse the trivia database, filter by keywords, and try AI-assisted search.</p>
+    </a>
     <article class="placeholder">
       <h3>Scoreboard</h3>
       <p>Track rankings and streaks once gameplay features are enabled.</p>

--- a/app/templates/question_browser.html
+++ b/app/templates/question_browser.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+{% block title %}Question Explorer · Panenka Live{% endblock %}
+{% block content %}
+<section class="card question-card">
+  <h2 class="card-title">Question Explorer</h2>
+  <p class="card-description">
+    Search and filter the trivia database by keywords. Enable AI assistance to expand your query with smart synonyms and related topics.
+  </p>
+  <form method="get" class="question-search">
+    <div class="field">
+      <label class="field-label" for="query">Keywords</label>
+      <input
+        id="query"
+        type="text"
+        name="q"
+        value="{{ query }}"
+        placeholder="e.g. футбол, сезон 3, музыка"
+      >
+    </div>
+    <div class="question-search__options">
+      <label class="checkbox">
+        <input
+          type="checkbox"
+          name="ai"
+          value="1"
+          {% if use_ai %}checked{% endif %}
+          {% if not ai_enabled %}disabled{% endif %}
+        >
+        <span>Use AI-assisted keyword expansion</span>
+      </label>
+      <label class="checkbox checkbox-inline" for="limit">
+        <span>Results limit</span>
+        <input
+          id="limit"
+          type="number"
+          name="limit"
+          min="5"
+          max="100"
+          value="{{ limit_value }}"
+          class="input-number"
+        >
+      </label>
+      <button type="submit" class="btn-primary">Search</button>
+    </div>
+    {% if not ai_enabled %}
+      <p class="helper-text">Set the <code>OPENAI_API_KEY</code> environment variable to unlock AI-powered search.</p>
+    {% endif %}
+  </form>
+  {% if ai_feedback %}
+    <p class="helper-text">{{ ai_feedback }}</p>
+  {% endif %}
+  {% if combined_keywords %}
+    <p class="helper-text">Applied keywords: {{ combined_keywords | join(", ") }}</p>
+  {% elif not query %}
+    <p class="helper-text">Showing the latest {{ result_count }} questions. Enter a search term to refine the list.</p>
+  {% endif %}
+  {% if results %}
+    <div class="table-wrapper">
+      <table class="question-table">
+        <thead>
+          <tr>
+            <th scope="col">Season</th>
+            <th scope="col">Row</th>
+            <th scope="col">Topic</th>
+            <th scope="col">Value</th>
+            <th scope="col">Question</th>
+            <th scope="col">Answer</th>
+            <th scope="col">Author</th>
+            <th scope="col">Editor</th>
+            <th scope="col">Played</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in results %}
+            <tr>
+              <td>{{ row.season_number }}</td>
+              <td>{{ row.row_number }}</td>
+              <td>{{ row.topic or "—" }}</td>
+              <td>
+                {% if row.question_value %}
+                  {{ row.question_value }}
+                {% else %}
+                  —
+                {% endif %}
+              </td>
+              <td class="question-table__text">{{ row.question_text | default("—") | replace('\n', '<br>') | safe }}</td>
+              <td class="question-table__text">{{ row.answer_text | default("—") | replace('\n', '<br>') | safe }}</td>
+              <td>{{ row.author or "—" }}</td>
+              <td>{{ row.editor or "—" }}</td>
+              <td>
+                {% if row.played_at %}
+                  {{ row.played_at }}
+                {% elif row.played_at_raw %}
+                  {{ row.played_at_raw }}
+                {% else %}
+                  —
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p class="helper-text">No questions match this request yet. Try different keywords or broaden the search.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask>=3.0.0
 gunicorn>=21.2.0
 boto3>=1.34.0
 psycopg2-binary>=2.9.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- add a dashboard tile that links to a new question explorer experience
- implement question search endpoints with optional AI keyword expansion and reusable SQL helper
- style the question explorer interface and add the requests dependency for API calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d85c7d7e5c832389f720f1b7f338bd