### PR TITLE
Optimize question table layout for full-screen display

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -52,6 +52,10 @@ body {
   gap: 2rem;
 }
 
+.layout--full {
+  width: min(1600px, 96vw);
+}
+
 .masthead {
   text-align: center;
 }
@@ -213,8 +217,44 @@ input:focus {
   color: var(--text-muted);
 }
 
+
 .question-card {
   gap: 1.75rem;
+}
+
+.question-table-page {
+  background: var(--card-bg);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 60px rgba(8, 16, 45, 0.45);
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  backdrop-filter: blur(18px);
+  display: grid;
+  grid-template-rows: auto auto auto 1fr auto;
+  gap: 1.25rem;
+  min-height: calc(100vh - 12rem);
+}
+
+.question-table-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.question-table-page__hint {
+  margin: 0;
+  max-width: 26ch;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.question-table-page__table {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .question-search {
@@ -274,6 +314,62 @@ input:focus {
   background: rgba(11, 19, 43, 0.75);
 }
 
+.table-wrapper--scrollable {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+.table-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.table-filters__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 160px;
+}
+
+.table-filters__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.table-filters__control {
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(12, 20, 43, 0.9);
+  color: inherit;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.table-filters__control:focus {
+  outline: none;
+  border-color: var(--border-glow);
+  box-shadow: 0 0 0 3px rgba(111, 123, 247, 0.35);
+}
+
+.table-filters__submit {
+  align-self: flex-end;
+}
+
+.table-summary {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.question-table-page .table-summary {
+  margin: 0;
+}
+
 .question-table {
   width: 100%;
   border-collapse: collapse;
@@ -303,6 +399,56 @@ input:focus {
 .question-table__text {
   white-space: pre-line;
   line-height: 1.5;
+}
+
+.table-muted {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+}
+
+.table-pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.question-table-page .table-pagination {
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 900px) {
+  .layout--full {
+    width: 100vw;
+    padding: clamp(1.5rem, 5vw, 2rem);
+  }
+
+  .question-table-page {
+    min-height: calc(100vh - 8rem);
+    padding: clamp(1.25rem, 4vw, 2rem);
+    grid-template-rows: auto auto 1fr auto;
+  }
+
+  .question-table-page__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .question-table-page__hint {
+    max-width: none;
+  }
+}
+
+.table-pagination__controls {
+  display: inline-flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.table-pagination__status {
+  color: var(--text-muted);
 }
 
 .buzzer-card {
@@ -380,6 +526,12 @@ input:focus {
 .btn-tertiary:hover {
   background: rgba(255, 255, 255, 0.18);
   transform: translateY(-1px);
+}
+
+.btn-tertiary--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .buzzer-sections {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <div class="background"></div>
-    <main class="layout">
+    <main class="layout{% block layout_modifier %}{% endblock %}">
       <header class="masthead">
         <h1 class="brand">Panenka Live</h1>
         <p class="subtitle">Interactive buzzer platform for quick-fire trivia.</p>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -20,6 +20,10 @@
       <h3>Question Explorer</h3>
       <p>Browse the trivia database, filter by keywords, and try AI-assisted search.</p>
     </a>
+    <a class="placeholder placeholder-link" href="{{ url_for('main.question_table') }}">
+      <h3>Question Table</h3>
+      <p>Просматривайте полный список импортированных вопросов из Google Sheets в табличном виде.</p>
+    </a>
     <article class="placeholder">
       <h3>Scoreboard</h3>
       <p>Track rankings and streaks once gameplay features are enabled.</p>

--- a/app/templates/question_table.html
+++ b/app/templates/question_table.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+{% block title %}База вопросов · Panenka Live{% endblock %}
+{% block layout_modifier %} layout--full{% endblock %}
+{% block content %}
+<section class="question-table-page">
+  <header class="question-table-page__header">
+    <div>
+      <h2 class="card-title">База вопросов</h2>
+  {% if stats.total %}
+        <p class="card-description">
+          Всего записей: <strong>{{ stats.total }}</strong>
+          {% if season_value %}
+            (сезон {{ season_value }})
+          {% endif %}
+          {% if stats.last_imported_at %}
+            · Последний импорт: {{ stats.last_imported_at }} UTC
+          {% else %}
+            · Время последнего импорта пока не определено.
+          {% endif %}
+        </p>
+  {% else %}
+        <p class="card-description">
+          Данные пока не импортированы. Запустите загрузку вопросов из Google Sheets, чтобы увидеть таблицу.
+        </p>
+  {% endif %}
+    </div>
+    {% if stats.total %}
+      <p class="question-table-page__hint">
+        Совет: используйте фильтры и навигацию, чтобы быстро переходить между сезонами.
+      </p>
+    {% endif %}
+  </header>
+
+  <form class="table-filters" method="get">
+    <label class="table-filters__field">
+      <span class="table-filters__label">Сезон</span>
+      <select name="season" class="table-filters__control">
+        <option value="" {% if not season_value %}selected{% endif %}>Все сезоны</option>
+        {% for season in seasons %}
+          <option value="{{ season }}" {% if season_value == season %}selected{% endif %}>Сезон {{ season }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label class="table-filters__field">
+      <span class="table-filters__label">Кол-во строк</span>
+      <input
+        class="table-filters__control"
+        type="number"
+        name="limit"
+        min="10"
+        max="500"
+        step="10"
+        value="{{ limit_value }}"
+      >
+    </label>
+    <button class="btn-primary table-filters__submit" type="submit">Обновить</button>
+  </form>
+
+  {% if rows %}
+    <div class="table-summary">
+      Показываются строки {{ display_from }}–{{ display_to }} из {{ total_count }}.
+      {% if has_next %}
+        Для остальных строк используйте кнопки навигации.
+      {% endif %}
+    </div>
+    <div class="question-table-page__table">
+      <div class="table-wrapper table-wrapper--scrollable">
+        <table class="question-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Сезон</th>
+            <th>#</th>
+            <th>Дата / редактор</th>
+            <th>Тема</th>
+            <th>Цена</th>
+            <th>Автор</th>
+            <th>Вопрос</th>
+            <th>Ответ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+            <tr>
+              <td>{{ row.id }}</td>
+              <td>{{ row.season_number }}</td>
+              <td>{{ row.row_number }}</td>
+              <td>
+                {% if row.played_at %}
+                  {{ row.played_at }}
+                {% elif row.played_at_raw %}
+                  {{ row.played_at_raw }}
+                {% else %}
+                  —
+                {% endif %}
+                {% if row.editor %}<br><span class="table-muted">{{ row.editor }}</span>{% endif %}
+              </td>
+              <td>{{ row.topic or "—" }}</td>
+              <td>{% if row.question_value is not none %}{{ row.question_value }}{% else %}—{% endif %}</td>
+              <td>{{ row.author or "—" }}</td>
+              <td class="question-table__text">{{ row.question_text or "—" }}</td>
+              <td class="question-table__text">{{ row.answer_text or "—" }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      </div>
+    </div>
+    <nav class="table-pagination">
+      <span class="table-pagination__status">
+        Страница {{ page_value }}
+      </span>
+      <div class="table-pagination__controls">
+        {% if has_previous %}
+          <a class="btn-tertiary" href="{{ previous_url }}">Назад</a>
+        {% else %}
+          <span class="btn-tertiary btn-tertiary--disabled">Назад</span>
+        {% endif %}
+        {% if has_next %}
+          <a class="btn-tertiary" href="{{ next_url }}">Вперёд</a>
+        {% else %}
+          <span class="btn-tertiary btn-tertiary--disabled">Вперёд</span>
+        {% endif %}
+      </div>
+    </nav>
+  {% else %}
+    <p class="helper-text">
+      Мы не нашли ни одной записи, удовлетворяющей условиям фильтра. Попробуйте выбрать другой сезон или изменить лимит.
+    </p>
+  {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow templates to opt into a full-width layout modifier
- restyle the question table view to span the full screen with a scrollable table area
- tweak responsive styles and pagination spacing for the question browser

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68d86839dd7083239a180079e8e7b664