### PR TITLE
Expand Question Explorer layout and seed sample data

### DIFF
--- a/app/question_store.py
+++ b/app/question_store.py
@@ -77,11 +77,10 @@ class QuestionStore:
         self._init_lock = threading.Lock()
         if enable_sample_data is None:
             flag = os.getenv("PANENKA_ENABLE_SAMPLE_DATA")
-            enable_sample_data = (
-                flag.lower() in {"1", "true", "yes", "on"}
-                if flag
-                else False
-            )
+            if flag is None:
+                enable_sample_data = True
+            else:
+                enable_sample_data = flag.lower() in {"1", "true", "yes", "on"}
         self._enable_sample_data = enable_sample_data
 
     @staticmethod

--- a/app/templates/question_browser.html
+++ b/app/templates/question_browser.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block layout_modifier %} layout--full{% endblock %}
 {% block title %}Question Explorer · Panenka Live{% endblock %}
 {% block content %}
 <section class="card question-card">

--- a/tests/test_question_search.py
+++ b/tests/test_question_search.py
@@ -32,22 +32,22 @@ def test_search_matches_any_keyword(tmp_path):
     assert any("радебе" in row["question_text"].lower() for row in results)
 
 
-def test_sample_questions_seeded(tmp_path):
+def test_sample_questions_seeded_by_default(tmp_path):
     db_path = tmp_path / "seeded.sqlite3"
-    store = QuestionStore(str(db_path), enable_sample_data=True)
+    store = QuestionStore(str(db_path))
 
     results = store.search_questions(limit=5)
 
-    assert results, "Expected bundled sample questions to be available when enabled"
+    assert results, "Expected bundled sample questions to be available by default"
     combined_text = " ".join(
         row["question_text"].lower() for row in results if row["question_text"]
     )
-    assert "радебе" in combined_text
+    assert "паненка" in combined_text
 
 
-def test_sample_questions_disabled_by_default(tmp_path):
+def test_sample_questions_can_be_disabled(tmp_path):
     db_path = tmp_path / "empty.sqlite3"
-    store = QuestionStore(str(db_path))
+    store = QuestionStore(str(db_path), enable_sample_data=False)
 
     results = store.search_questions(limit=5)
 


### PR DESCRIPTION
## Summary
- apply the wide layout modifier to the Question Explorer so the table uses the full width
- enable the bundled question dataset by default so the explorer includes the imported document content
- update the search tests to reflect the new default seeding while keeping the opt-out path

## Testing
- pytest tests/test_question_search.py

------
https://chatgpt.com/codex/tasks/task_e_68d871f9f9488323a928cdd697c13e12