### PR TITLE
Refine question browser and auth redirects

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1029,8 +1029,11 @@ def buzzer_leave(code):
     return jsonify({"status": "ok"})
 
 
-@bp.route("/", methods=["GET", "POST"])
+@bp.route("/login", methods=["GET", "POST"])
 def login():
+    if session.get("user_id") and request.method == "GET":
+        return redirect(url_for("main.dashboard"))
+
     error = None
     if request.method == "POST":
         login_code = request.form.get("login", "").strip()
@@ -1056,6 +1059,17 @@ def login():
         flash(error, "error")
 
     return render_template("login.html")
+
+
+@bp.route("/", methods=["GET", "POST"])
+def root():
+    if request.method == "POST":
+        return login()
+
+    if session.get("user_id"):
+        return redirect(url_for("main.dashboard"))
+
+    return redirect(url_for("main.login"))
 
 
 @bp.route("/dashboard")
@@ -1179,6 +1193,7 @@ def question_table():
 
 
 @bp.route("/logout")
+@login_required
 def logout():
     session.clear()
     return redirect(url_for("main.login"))

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -67,6 +67,16 @@ body {
   letter-spacing: -0.04em;
 }
 
+.brand a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand a:hover,
+.brand a:focus-visible {
+  text-decoration: underline;
+}
+
 .subtitle {
   margin: 0.5rem 0 0;
   font-weight: 300;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,7 +13,7 @@
     <div class="background"></div>
     <main class="layout{% block layout_modifier %}{% endblock %}">
       <header class="masthead">
-        <h1 class="brand">Panenka Live</h1>
+        <h1 class="brand"><a href="{{ url_for('main.dashboard') }}">Panenka Live</a></h1>
         <p class="subtitle">Interactive buzzer platform for quick-fire trivia.</p>
       </header>
       {% with messages = get_flashed_messages(with_categories=true) %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -20,10 +20,6 @@
       <h3>Question Explorer</h3>
       <p>Browse the trivia database, filter by keywords, and try AI-assisted search.</p>
     </a>
-    <a class="placeholder placeholder-link" href="{{ url_for('main.question_table') }}">
-      <h3>Question Table</h3>
-      <p>Просматривайте полный список импортированных вопросов из Google Sheets в табличном виде.</p>
-    </a>
     <article class="placeholder">
       <h3>Scoreboard</h3>
       <p>Track rankings and streaks once gameplay features are enabled.</p>

--- a/app/templates/question_browser.html
+++ b/app/templates/question_browser.html
@@ -61,7 +61,6 @@
         <thead>
           <tr>
             <th scope="col">Season</th>
-            <th scope="col">Row</th>
             <th scope="col">Topic</th>
             <th scope="col">Value</th>
             <th scope="col">Question</th>
@@ -75,7 +74,6 @@
           {% for row in results %}
             <tr>
               <td>{{ row.season_number }}</td>
-              <td>{{ row.row_number }}</td>
               <td>{{ row.topic or "—" }}</td>
               <td>
                 {% if row.question_value %}


### PR DESCRIPTION
## Summary
- redirect logged-in users away from /login and gate anonymous traffic to the login page
- link the masthead brand to the dashboard and streamline the dashboard cards
- simplify the question explorer table by removing the Row column

## Testing
- pytest tests/test_question_search.py

------
https://chatgpt.com/codex/tasks/task_e_68da9a4fb0ac832390a6f35ddc209354