### PR TITLE
Add metadata filters and stats to question explorer

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1091,6 +1091,20 @@ def question_browser():
         limit_value = 50
     limit_value = min(limit_value, 100)
 
+    season_filter = request.args.get("season", type=int)
+    if season_filter is not None and season_filter <= 0:
+        season_filter = None
+
+    value_filter = request.args.get("value", type=int)
+    if value_filter is not None and value_filter <= 0:
+        value_filter = None
+
+    author_filter_raw = request.args.get("author", "")
+    author_filter = author_filter_raw.strip() or None
+
+    editor_filter_raw = request.args.get("editor", "")
+    editor_filter = editor_filter_raw.strip() or None
+
     ai_enabled = _get_sanitized_env("OPENAI_API_KEY") is not None
     use_ai = request.args.get("ai") == "1"
 
@@ -1111,8 +1125,20 @@ def question_browser():
 
     combined_keywords = list(dict.fromkeys(manual_keywords + ai_keywords))
 
-    results = question_store.search_questions(combined_keywords, limit=limit_value)
+    results = question_store.search_questions(
+        combined_keywords,
+        limit=limit_value,
+        season_number=season_filter,
+        question_value=value_filter,
+        author=author_filter,
+        editor=editor_filter,
+    )
     result_count = len(results)
+
+    seasons = question_store.list_seasons()
+    values = question_store.list_question_values()
+    authors = question_store.list_authors()
+    editors = question_store.list_editors()
 
     return render_template(
         "question_browser.html",
@@ -1126,6 +1152,14 @@ def question_browser():
         use_ai=use_ai,
         limit_value=limit_value,
         result_count=result_count,
+        season_filter=season_filter,
+        value_filter=value_filter,
+        author_filter=author_filter,
+        editor_filter=editor_filter,
+        seasons=seasons,
+        values=values,
+        authors=authors,
+        editors=editors,
     )
 
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -151,7 +151,24 @@ input[type="password"] {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+select {
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(12, 20, 43, 0.9);
+  color: inherit;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
 input:focus {
+  outline: none;
+  border-color: var(--border-glow);
+  box-shadow: 0 0 0 3px rgba(111, 123, 247, 0.35);
+}
+
+select:focus {
   outline: none;
   border-color: var(--border-glow);
   box-shadow: 0 0 0 3px rgba(111, 123, 247, 0.35);
@@ -277,6 +294,12 @@ input:focus {
   flex-wrap: wrap;
   gap: 1rem;
   align-items: center;
+}
+
+.question-search__filters {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .checkbox {

--- a/app/templates/question_browser.html
+++ b/app/templates/question_browser.html
@@ -43,6 +43,44 @@
       </label>
       <button type="submit" class="btn-primary">Search</button>
     </div>
+    <div class="question-search__filters">
+      <label class="field">
+        <span class="field-label">Сезон</span>
+        <select name="season">
+          <option value="" {% if not season_filter %}selected{% endif %}>Все сезоны</option>
+          {% for season in seasons %}
+            <option value="{{ season }}" {% if season_filter == season %}selected{% endif %}>Сезон {{ season }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span class="field-label">Номинал</span>
+        <select name="value">
+          <option value="" {% if not value_filter %}selected{% endif %}>Все номиналы</option>
+          {% for value in values %}
+            <option value="{{ value }}" {% if value_filter == value %}selected{% endif %}>{{ value }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span class="field-label">Автор</span>
+        <select name="author">
+          <option value="" {% if not author_filter %}selected{% endif %}>Все авторы</option>
+          {% for author in authors %}
+            <option value="{{ author }}" {% if author_filter == author %}selected{% endif %}>{{ author }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span class="field-label">Редактор</span>
+        <select name="editor">
+          <option value="" {% if not editor_filter %}selected{% endif %}>Все редакторы</option>
+          {% for editor in editors %}
+            <option value="{{ editor }}" {% if editor_filter == editor %}selected{% endif %}>{{ editor }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
     {% if not ai_enabled %}
       <p class="helper-text">Set the <code>OPENAI_API_KEY</code> environment variable to unlock AI-powered search.</p>
     {% endif %}
@@ -68,6 +106,8 @@
             <th scope="col">Author</th>
             <th scope="col">Editor</th>
             <th scope="col">Played</th>
+            <th scope="col">Взято / Не взято</th>
+            <th scope="col">Комментарии</th>
           </tr>
         </thead>
         <tbody>
@@ -95,6 +135,15 @@
                   —
                 {% endif %}
               </td>
+              <td>
+                {% if row.taken_count is not none or row.not_taken_count is not none %}
+                  <span class="table-muted">Взято:</span> {{ row.taken_count if row.taken_count is not none else "—" }}<br>
+                  <span class="table-muted">Не взято:</span> {{ row.not_taken_count if row.not_taken_count is not none else "—" }}
+                {% else %}
+                  —
+                {% endif %}
+              </td>
+              <td class="question-table__text">{{ row.comment | default("—") | replace('\n', '<br>') | safe }}</td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- add season, value, author, and editor filters to the question explorer page
- surface taken/not-taken statistics and comments in the question results table
- expose store helpers for distinct metadata values and cover the new filters with tests

## Testing
- pytest tests/test_question_search.py

------
https://chatgpt.com/codex/tasks/task_e_68da9eeef0188323a351b31247f44ccf