### PR TITLE
Add range filters and compact styling for question browser

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1125,6 +1125,29 @@ def question_browser():
 
     combined_keywords = list(dict.fromkeys(manual_keywords + ai_keywords))
 
+    taken_bounds = question_store.get_taken_not_taken_bounds()
+    taken_max_bound, not_taken_max_bound = taken_bounds
+
+    taken_min = request.args.get("taken_min", type=int)
+    if taken_min is None or taken_min < 0:
+        taken_min = 0
+
+    taken_max = request.args.get("taken_max", type=int)
+    if taken_max is None:
+        taken_max = taken_max_bound
+    else:
+        taken_max = max(taken_min, min(taken_max, taken_max_bound))
+
+    not_taken_min = request.args.get("not_taken_min", type=int)
+    if not_taken_min is None or not_taken_min < 0:
+        not_taken_min = 0
+
+    not_taken_max = request.args.get("not_taken_max", type=int)
+    if not_taken_max is None:
+        not_taken_max = not_taken_max_bound
+    else:
+        not_taken_max = max(not_taken_min, min(not_taken_max, not_taken_max_bound))
+
     results = question_store.search_questions(
         combined_keywords,
         limit=limit_value,
@@ -1132,6 +1155,10 @@ def question_browser():
         question_value=value_filter,
         author=author_filter,
         editor=editor_filter,
+        taken_min=taken_min,
+        taken_max=taken_max,
+        not_taken_min=not_taken_min,
+        not_taken_max=not_taken_max,
     )
     result_count = len(results)
 
@@ -1160,6 +1187,12 @@ def question_browser():
         values=values,
         authors=authors,
         editors=editors,
+        taken_min=taken_min,
+        taken_max=taken_max,
+        not_taken_min=not_taken_min,
+        not_taken_max=not_taken_max,
+        taken_max_bound=taken_max_bound,
+        not_taken_max_bound=not_taken_max_bound,
     )
 
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -10,6 +10,7 @@
   --accent: #ffb703;
   --accent-hover: #f4a261;
   --error: #ff6b6b;
+  --success: #4ade80;
 }
 
 * {
@@ -299,7 +300,120 @@ select:focus {
 .question-search__filters {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.field--compact {
+  min-width: 0;
+}
+
+.field--compact select,
+.field--compact input,
+.field--compact .field-label {
+  font-size: 0.95rem;
+}
+
+.field--compact select {
+  padding: 0.65rem 0.75rem;
+}
+
+.question-search__range-filters {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.range-filter {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.dual-range {
+  position: relative;
+  height: 2.25rem;
+  --range-active: var(--accent);
+}
+
+.dual-range[data-range-group="taken"] {
+  --range-active: var(--success);
+}
+
+.dual-range[data-range-group="not-taken"] {
+  --range-active: var(--error);
+}
+
+.dual-range input[type="range"] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  margin: 0;
+  background: none;
+  pointer-events: none;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 100%;
+}
+
+.dual-range input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 1rem;
+  width: 1rem;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.dual-range input[type="range"]::-moz-range-thumb {
+  height: 1rem;
+  width: 1rem;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.dual-range input[type="range"]::-webkit-slider-runnable-track {
+  height: 100%;
+}
+
+.dual-range input[type="range"]::-moz-range-track {
+  height: 100%;
+  background: transparent;
+}
+
+.dual-range input[data-role="min"] {
+  z-index: 2;
+}
+
+.dual-range input[data-role="max"] {
+  z-index: 3;
+}
+
+.dual-range__track {
+  position: absolute;
+  inset: calc(50% - 0.175rem) 0;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  pointer-events: none;
+}
+
+.range-filter__values {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.range-filter__separator {
+  opacity: 0.6;
 }
 
 .checkbox {
@@ -338,6 +452,35 @@ select:focus {
   outline: none;
   border-color: var(--border-glow);
   box-shadow: 0 0 0 3px rgba(111, 123, 247, 0.35);
+}
+
+.taken-indicators {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.taken-indicator {
+  min-width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0 0.5rem;
+  box-shadow: 0 0.2rem 0.6rem rgba(12, 20, 43, 0.35);
+}
+
+.taken-indicator--positive {
+  background: var(--success);
+  color: #052e16;
+}
+
+.taken-indicator--negative {
+  background: var(--error);
+  color: #450a0a;
 }
 
 .table-wrapper {

--- a/app/templates/question_browser.html
+++ b/app/templates/question_browser.html
@@ -44,7 +44,7 @@
       <button type="submit" class="btn-primary">Search</button>
     </div>
     <div class="question-search__filters">
-      <label class="field">
+      <label class="field field--compact">
         <span class="field-label">Сезон</span>
         <select name="season">
           <option value="" {% if not season_filter %}selected{% endif %}>Все сезоны</option>
@@ -53,7 +53,7 @@
           {% endfor %}
         </select>
       </label>
-      <label class="field">
+      <label class="field field--compact">
         <span class="field-label">Номинал</span>
         <select name="value">
           <option value="" {% if not value_filter %}selected{% endif %}>Все номиналы</option>
@@ -62,7 +62,7 @@
           {% endfor %}
         </select>
       </label>
-      <label class="field">
+      <label class="field field--compact">
         <span class="field-label">Автор</span>
         <select name="author">
           <option value="" {% if not author_filter %}selected{% endif %}>Все авторы</option>
@@ -71,7 +71,7 @@
           {% endfor %}
         </select>
       </label>
-      <label class="field">
+      <label class="field field--compact">
         <span class="field-label">Редактор</span>
         <select name="editor">
           <option value="" {% if not editor_filter %}selected{% endif %}>Все редакторы</option>
@@ -80,6 +80,66 @@
           {% endfor %}
         </select>
       </label>
+    </div>
+    <div class="question-search__range-filters">
+      <div class="range-filter">
+        <span class="field-label">Взято</span>
+        <div class="dual-range" data-range-group="taken">
+          <input
+            type="range"
+            name="taken_min"
+            min="0"
+            max="{{ taken_max_bound }}"
+            value="{{ taken_min }}"
+            step="1"
+            data-role="min"
+          >
+          <input
+            type="range"
+            name="taken_max"
+            min="0"
+            max="{{ taken_max_bound }}"
+            value="{{ taken_max }}"
+            step="1"
+            data-role="max"
+          >
+          <div class="dual-range__track" aria-hidden="true"></div>
+        </div>
+        <div class="range-filter__values">
+          <span data-role="display-min">{{ taken_min }}</span>
+          <span class="range-filter__separator">—</span>
+          <span data-role="display-max">{{ taken_max }}</span>
+        </div>
+      </div>
+      <div class="range-filter">
+        <span class="field-label">Не взято</span>
+        <div class="dual-range" data-range-group="not-taken">
+          <input
+            type="range"
+            name="not_taken_min"
+            min="0"
+            max="{{ not_taken_max_bound }}"
+            value="{{ not_taken_min }}"
+            step="1"
+            data-role="min"
+          >
+          <input
+            type="range"
+            name="not_taken_max"
+            min="0"
+            max="{{ not_taken_max_bound }}"
+            value="{{ not_taken_max }}"
+            step="1"
+            data-role="max"
+          >
+          <div class="dual-range__track" aria-hidden="true"></div>
+        </div>
+        <div class="range-filter__values">
+          <span data-role="display-min">{{ not_taken_min }}</span>
+          <span class="range-filter__separator">—</span>
+          <span data-role="display-max">{{ not_taken_max }}</span>
+        </div>
+      </div>
     </div>
     {% if not ai_enabled %}
       <p class="helper-text">Set the <code>OPENAI_API_KEY</code> environment variable to unlock AI-powered search.</p>
@@ -137,8 +197,14 @@
               </td>
               <td>
                 {% if row.taken_count is not none or row.not_taken_count is not none %}
-                  <span class="table-muted">Взято:</span> {{ row.taken_count if row.taken_count is not none else "—" }}<br>
-                  <span class="table-muted">Не взято:</span> {{ row.not_taken_count if row.not_taken_count is not none else "—" }}
+                  <div class="taken-indicators">
+                    {% if row.taken_count is not none %}
+                      <span class="taken-indicator taken-indicator--positive">{{ row.taken_count }}</span>
+                    {% endif %}
+                    {% if row.not_taken_count is not none %}
+                      <span class="taken-indicator taken-indicator--negative">{{ row.not_taken_count }}</span>
+                    {% endif %}
+                  </div>
                 {% else %}
                   —
                 {% endif %}
@@ -153,4 +219,75 @@
     <p class="helper-text">No questions match this request yet. Try different keywords or broaden the search.</p>
   {% endif %}
 </section>
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ super() }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const groups = document.querySelectorAll('.dual-range');
+      groups.forEach(function (group) {
+        const minInput = group.querySelector('input[data-role="min"]');
+        const maxInput = group.querySelector('input[data-role="max"]');
+        const track = group.querySelector('.dual-range__track');
+        const container = group.parentElement;
+        const displayMin = container.querySelector('[data-role="display-min"]');
+        const displayMax = container.querySelector('[data-role="display-max"]');
+
+        if (!minInput || !maxInput || !track || !displayMin || !displayMax) {
+          return;
+        }
+
+        const update = function (changed) {
+          let minValue = parseInt(minInput.value || '0', 10);
+          let maxValue = parseInt(maxInput.value || '0', 10);
+
+          if (Number.isNaN(minValue)) {
+            minValue = 0;
+          }
+          if (Number.isNaN(maxValue)) {
+            maxValue = 0;
+          }
+
+          if (minValue > maxValue) {
+            if (changed === minInput) {
+              maxValue = minValue;
+              maxInput.value = String(maxValue);
+            } else {
+              minValue = maxValue;
+              minInput.value = String(minValue);
+            }
+          }
+
+          displayMin.textContent = String(minValue);
+          displayMax.textContent = String(maxValue);
+
+          const maxRange = Math.max(
+            Number(minInput.max) || 0,
+            Number(maxInput.max) || 0
+          );
+
+          const progressStart = maxRange > 0 ? (minValue / maxRange) * 100 : 0;
+          const progressEnd = maxRange > 0 ? (maxValue / maxRange) * 100 : 0;
+          const groupColor = getComputedStyle(group).getPropertyValue('--range-active').trim();
+          const accentColor = getComputedStyle(document.documentElement)
+            .getPropertyValue('--accent')
+            .trim() || '#ffb703';
+          const activeColor = groupColor || accentColor;
+          const trackColor = 'rgba(255, 255, 255, 0.18)';
+
+          track.style.background = `linear-gradient(to right, ${trackColor} ${progressStart}%, ${activeColor} ${progressStart}%, ${activeColor} ${progressEnd}%, ${trackColor} ${progressEnd}%)`;
+        };
+
+        minInput.addEventListener('input', function () {
+          update(minInput);
+        });
+        maxInput.addEventListener('input', function () {
+          update(maxInput);
+        });
+
+        update();
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add server-side support for filtering questions by taken and not-taken counts
- surface dual-range sliders and compact dropdown styling in the question browser
- render taken/not-taken counts as color-coded badges and cover the new behaviour with tests

## Testing
- `pytest tests/test_question_search.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa251b8848323858e5d7b393ab517