### PR TITLE
Add historical results dashboard page

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -991,6 +991,128 @@ select:focus {
   color: #f5f6ff;
 }
 
+.historical-card {
+  gap: 1.5rem;
+}
+
+.historical-header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-end;
+}
+
+.historical-intro {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 32rem;
+}
+
+.historical-filter {
+  display: grid;
+  gap: 0.5rem;
+  min-width: min(320px, 100%);
+}
+
+.historical-filter__controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.historical-filter select {
+  min-width: 220px;
+}
+
+.historical-reset {
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.historical-reset:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.historical-hint {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.historical-fight-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.historical-fight {
+  background: rgba(12, 21, 45, 0.85);
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.historical-fight__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.historical-fight__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.historical-fight__code {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.historical-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.historical-table th,
+.historical-table td {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+}
+
+.historical-table thead tr {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.historical-table tbody tr {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.historical-table tbody tr:first-child {
+  border-top: none;
+}
+
+.historical-player--highlight {
+  background: rgba(255, 107, 107, 0.12);
+}
+
+.historical-player--highlight td {
+  color: var(--error);
+  font-weight: 600;
+}
+
+.historical-empty {
+  margin: 0;
+  color: var(--text-muted);
+}
+
 @media (max-width: 600px) {
   .card {
     padding: 1.75rem;

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -20,10 +20,10 @@
       <h3>Question Explorer</h3>
       <p>Browse the trivia database, filter by keywords, and try AI-assisted search.</p>
     </a>
-    <article class="placeholder">
-      <h3>Scoreboard</h3>
-      <p>Track rankings and streaks once gameplay features are enabled.</p>
-    </article>
+    <a class="placeholder placeholder-link" href="{{ url_for('main.historical_results') }}">
+      <h3>Исторические бои</h3>
+      <p>Просматривайте результаты прошедших боёв и подсвечивайте выбранного игрока.</p>
+    </a>
   </div>
   <a class="btn-secondary" href="{{ url_for('main.logout') }}">Log out</a>
 </section>

--- a/app/templates/historical_results.html
+++ b/app/templates/historical_results.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% block title %}История боёв · Panenka Live{% endblock %}
+{% block layout_modifier %} layout--full{% endblock %}
+{% block content %}
+<section class="card historical-card">
+  <header class="historical-header">
+    <div class="historical-intro">
+      <h2 class="card-title">История боёв</h2>
+      <p class="card-description">
+        {% if season_number %}
+          Сезон {{ season_number }}. Выберите игрока, чтобы увидеть его результаты в боях.
+        {% else %}
+          Выберите игрока, чтобы увидеть его результаты в боях.
+        {% endif %}
+      </p>
+    </div>
+    <form class="historical-filter" method="get">
+      <label class="field-label" for="player">Игрок</label>
+      <div class="historical-filter__controls">
+        <select id="player" name="player" onchange="this.form.submit()">
+          <option value="">Все игроки</option>
+          {% for player_name in all_players %}
+            <option value="{{ player_name }}" {% if player_name == selected_player %}selected{% endif %}>{{ player_name }}</option>
+          {% endfor %}
+        </select>
+        {% if selected_player %}
+          <a class="historical-reset" href="{{ url_for('main.historical_results') }}">Сбросить</a>
+        {% endif %}
+      </div>
+    </form>
+  </header>
+  <p class="historical-hint">
+    {% if selected_player and selected_player_found %}
+      Показаны бои с участием игрока {{ selected_player }}.
+    {% elif selected_player and not selected_player_found %}
+      Игрок «{{ selected_player }}» не найден в исторических данных.
+    {% else %}
+      Используйте фильтр, чтобы подсветить конкретного участника и посмотреть его результаты.
+    {% endif %}
+  </p>
+  {% if fights %}
+    <div class="historical-fight-list">
+      {% for fight in fights %}
+        <article class="historical-fight">
+          <header class="historical-fight__header">
+            <h3 class="historical-fight__title">Тур {{ fight.tour_number }}, бой {{ fight.letter or fight.fight_code }}</h3>
+            <p class="historical-fight__code">{{ fight.fight_code }}</p>
+          </header>
+          <table class="historical-table">
+            <thead>
+              <tr>
+                <th scope="col">Место</th>
+                <th scope="col">Игрок</th>
+                <th scope="col">Итог</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for player in fight.players %}
+                <tr class="{% if selected_player_found and player.name == selected_player %}historical-player--highlight{% endif %}">
+                  <td>{{ loop.index }}</td>
+                  <td>{{ player.name or '—' }}</td>
+                  <td>{{ player.total }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="historical-empty">
+      {% if selected_player and selected_player_found %}
+        Для выбранного игрока пока нет боёв.
+      {% elif selected_player and not selected_player_found %}
+        Измените фильтр, чтобы увидеть доступные результаты.
+      {% else %}
+        Исторические данные о боях появятся здесь.
+      {% endif %}
+    </p>
+  {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a historical results page that loads fight data, filters by player, and highlights the selected competitor
- link the new historical results view from the dashboard and apply dedicated styling for the results tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dab01c7b908323b69e5b2e542b27b4