### PR TITLE
Обновить соответствия имён пользователей

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -43,7 +43,7 @@ DEFAULT_FALLBACK_USERS = [
     {
         "login": "888",
         "password": "6969",
-        "name": "Integration Test Player",
+        "name": "Тестовый игрок",
     }
 ]
 
@@ -80,6 +80,8 @@ _MANUAL_NAME_OVERRIDES = {
     "максим к.": "Максим Корнеевец",
     "станислав с-б.": "Станислав Силицкий-Бутрим",
     "хорхе": "Хорхе Чаос",
+    "михась": "Михась Коберник",
+    "шабанов": "Сергей Шабанов",
 }
 _MANUAL_OVERRIDE_TARGETS = set(_MANUAL_NAME_OVERRIDES.values())
 

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -28,7 +28,7 @@ class AuthJsonLoginTestCase(unittest.TestCase):
             {
                 "login": LOGIN_CODE,
                 "password": PASSWORD_CODE,
-                "name": "Integration Test Player",
+                "name": "Тестовый игрок",
             }
         ]
     }
@@ -99,7 +99,7 @@ class AuthJsonLoginTestCase(unittest.TestCase):
                 {
                     "login": 123,
                     "password": 4567,
-                    "name": "Numeric Player",
+                    "name": "Числовой игрок",
                 }
             ]
         }
@@ -112,7 +112,7 @@ class AuthJsonLoginTestCase(unittest.TestCase):
 
         self.assertIn("123", credentials)
         self.assertEqual(credentials["123"]["password"], "4567")
-        self.assertEqual(credentials["123"]["name"], "Numeric Player")
+        self.assertEqual(credentials["123"]["name"], "Числовой игрок")
 
 
 if __name__ == "__main__":  # pragma: no cover - allows running file directly


### PR DESCRIPTION
## Summary
- добавить ручные соответствия для игроков Михась Коберник и Сергей Шабанов
- привести запасного пользователя и связанные тесты к русским именам

## Testing
- pytest tests/test_auth_login.py *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68dbb057f7988323b71bc7d0c5cd1416