### PR TITLE
Load historical results without bundling database

### DIFF
--- a/app/historical_results_loader.py
+++ b/app/historical_results_loader.py
@@ -1,0 +1,356 @@
+"""Helpers for assembling historical fight results datasets."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import tempfile
+import time
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+from .season2 import Season2Importer, Season2ResultsStore
+
+DEFAULT_SEASON1_FIXTURE = Path("app/static/data/season01_tour_results.json")
+DEFAULT_SEASON2_DATA_ROOT = Path("data/raw/season02/csv")
+DEFAULT_SEASON2_MANIFEST = Path("data/raw/season02/manifest.json")
+
+_FIGHT_CODE_PATTERN = re.compile(
+    r"S(?P<season>\d{2})E(?P<tour>\d{2})F(?P<fight>\d{2})",
+    flags=re.IGNORECASE,
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@lru_cache(maxsize=1)
+def load_historical_dataset(
+    season1_json: str | Path = DEFAULT_SEASON1_FIXTURE,
+    season2_data_root: str | Path = DEFAULT_SEASON2_DATA_ROOT,
+    season2_manifest: str | Path = DEFAULT_SEASON2_MANIFEST,
+) -> dict[str, Iterable]:
+    """Load historical fight payload assembled from seasons 1 and 2.
+
+    The heavy lifting is delegated to :func:`build_historical_database`, which
+    reuses the Season 2 importer to normalise CSV snapshots. To avoid committing
+    binary assets the SQLite database is created inside a temporary directory
+    and converted to a lightweight in-memory representation before returning to
+    the caller. Results are cached across calls for the lifetime of the
+    process so repeated requests do not rebuild the dataset.
+    """
+
+    season1_path = Path(season1_json)
+    season2_root_path = Path(season2_data_root)
+    season2_manifest_path = Path(season2_manifest)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output = Path(tmpdir) / "historical.sqlite3"
+        build_historical_database(
+            season1_json=season1_path,
+            season2_data_root=season2_root_path,
+            season2_manifest=season2_manifest_path,
+            output=output,
+        )
+        fights, seasons = _extract_historical_records(output)
+
+    raw_names = [
+        participant["display"]
+        for fight in fights
+        for participant in fight.get("participants", [])
+    ]
+
+    return {
+        "fights": fights,
+        "raw_names": raw_names,
+        "seasons": seasons,
+    }
+
+
+def build_historical_database(
+    *,
+    season1_json: Path,
+    season2_data_root: Path,
+    season2_manifest: Path,
+    output: Path,
+) -> dict[str, dict[str, int]]:
+    """Compile season 1 and 2 fight snapshots into a SQLite bundle."""
+
+    if output.exists():
+        output.unlink()
+
+    store = Season2ResultsStore(db_path=str(output))
+
+    season2_summary = _import_season2(
+        store,
+        data_root=season2_data_root,
+        manifest=season2_manifest,
+    )
+
+    with store.connection() as conn:
+        season1_summary = _insert_season1_results(conn, fixture_path=season1_json)
+        conn.commit()
+
+    return {"season1": season1_summary, "season2": season2_summary}
+
+
+def _sanitize_name(value: str | None) -> str:
+    value = (value or "").strip()
+    return _WHITESPACE_RE.sub(" ", value)
+
+
+def _normalize_name(value: str | None) -> str:
+    sanitized = _sanitize_name(value)
+    return sanitized.lower()
+
+
+def _ensure_season(conn: sqlite3.Connection, season_number: int) -> int:
+    row = conn.execute(
+        "SELECT id FROM seasons WHERE season_number = ?",
+        (season_number,),
+    ).fetchone()
+    if row is not None:
+        return int(row["id"])
+    cursor = conn.execute(
+        "INSERT INTO seasons (season_number, slug) VALUES (?, ?)",
+        (season_number, f"{season_number:02d}"),
+    )
+    return int(cursor.lastrowid)
+
+
+def _ensure_tour(
+    conn: sqlite3.Connection,
+    *,
+    season_id: int,
+    tour_number: int,
+    gid: int | None,
+) -> int:
+    row = conn.execute(
+        "SELECT id FROM tours WHERE season_id = ? AND tour_number = ?",
+        (season_id, tour_number),
+    ).fetchone()
+    if row is not None:
+        tour_id = int(row["id"])
+        if gid is not None:
+            conn.execute(
+                "UPDATE tours SET gid = ? WHERE id = ?",
+                (gid, tour_id),
+            )
+        return tour_id
+    cursor = conn.execute(
+        "INSERT INTO tours (season_id, tour_number, gid) VALUES (?, ?, ?)",
+        (season_id, tour_number, gid),
+    )
+    return int(cursor.lastrowid)
+
+
+def _record_import(
+    conn: sqlite3.Connection,
+    *,
+    source: str,
+    identifier: str,
+    season_number: int,
+) -> int:
+    started_at = time.time()
+    cursor = conn.execute(
+        (
+            "INSERT INTO imports (source, source_identifier, season_number, started_at, status) "
+            "VALUES (?, ?, ?, ?, ?)"
+        ),
+        (source, identifier, season_number, started_at, "running"),
+    )
+    import_id = int(cursor.lastrowid)
+    conn.execute(
+        "UPDATE imports SET finished_at = ?, status = ? WHERE id = ?",
+        (time.time(), "success", import_id),
+    )
+    return import_id
+
+
+def _parse_fight_code(code: str) -> tuple[int, int, int]:
+    match = _FIGHT_CODE_PATTERN.fullmatch(code.strip())
+    if not match:
+        raise ValueError(f"Unrecognised fight code: {code!r}")
+    return (
+        int(match.group("season")),
+        int(match.group("tour")),
+        int(match.group("fight")),
+    )
+
+
+def _insert_season1_results(
+    conn: sqlite3.Connection,
+    *,
+    fixture_path: Path,
+) -> dict[str, int]:
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    season_number = int(data.get("season_number") or 1)
+    season_id = _ensure_season(conn, season_number)
+    import_id = _record_import(
+        conn,
+        source="season01_fixture",
+        identifier=str(fixture_path),
+        season_number=season_number,
+    )
+
+    fights_inserted = 0
+    participants_inserted = 0
+    questions_inserted = 0
+    results_inserted = 0
+
+    for tour in data.get("tours", []):
+        tour_number = int(tour.get("tour_number") or 0)
+        gid = tour.get("gid")
+        tour_id = _ensure_tour(
+            conn,
+            season_id=season_id,
+            tour_number=tour_number,
+            gid=int(gid) if isinstance(gid, int) else None,
+        )
+        for fight in tour.get("fights", []):
+            fight_code = fight.get("code")
+            if not fight_code:
+                continue
+            _, _, fight_number = _parse_fight_code(str(fight_code))
+            letter = fight.get("letter")
+            conn.execute("DELETE FROM fights WHERE fight_code = ?", (fight_code,))
+            cursor = conn.execute(
+                (
+                    "INSERT INTO fights (tour_id, fight_number, ordinal, fight_code, letter, imported_at, source_path, import_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                ),
+                (
+                    tour_id,
+                    fight_number,
+                    fight_number,
+                    fight_code,
+                    letter,
+                    time.time(),
+                    str(fixture_path),
+                    import_id,
+                ),
+            )
+            fight_id = int(cursor.lastrowid)
+            fights_inserted += 1
+
+            participant_ids: list[int] = []
+            seen_normalized: set[str] = set()
+            players = fight.get("players", [])
+            for seat_index, player in enumerate(players, start=1):
+                display_name = _sanitize_name(player.get("name"))
+                if not display_name or display_name in {"-", "—", "--"}:
+                    display_name = f"Неизвестный игрок {seat_index}"
+                normalized = _normalize_name(display_name)
+                if normalized in seen_normalized:
+                    normalized = f"{normalized}#{seat_index}"
+                seen_normalized.add(normalized)
+                total = int(player.get("total") or 0)
+                cursor = conn.execute(
+                    (
+                        "INSERT INTO fight_participants (fight_id, display_name, normalized_name, seat_index, total_score) "
+                        "VALUES (?, ?, ?, ?, ?)"
+                    ),
+                    (fight_id, display_name, normalized, seat_index, total),
+                )
+                participant_ids.append(int(cursor.lastrowid))
+            participants_inserted += len(participant_ids)
+
+            questions = fight.get("questions", [])
+            for question in questions:
+                order = int(question.get("order") or 0)
+                nominal = int(question.get("nominal") or 0)
+                theme = question.get("theme")
+                cursor = conn.execute(
+                    (
+                        "INSERT INTO questions (fight_id, question_order, nominal, theme, source_row) "
+                        "VALUES (?, ?, ?, ?, ?)"
+                    ),
+                    (fight_id, order, nominal, theme, None),
+                )
+                question_id = int(cursor.lastrowid)
+                questions_inserted += 1
+
+                results = list(question.get("results", []))
+                for participant_id, result in zip(participant_ids, results):
+                    delta = int(result.get("delta") or 0)
+                    is_correct = 1 if result.get("is_correct") else 0
+                    conn.execute(
+                        (
+                            "INSERT INTO question_results (question_id, participant_id, delta, is_correct) "
+                            "VALUES (?, ?, ?, ?)"
+                        ),
+                        (question_id, participant_id, delta, is_correct),
+                    )
+                    results_inserted += 1
+
+    return {
+        "fights": fights_inserted,
+        "participants": participants_inserted,
+        "questions": questions_inserted,
+        "question_results": results_inserted,
+    }
+
+
+def _import_season2(
+    store: Season2ResultsStore,
+    *,
+    data_root: Path,
+    manifest: Path,
+) -> dict[str, int]:
+    importer = Season2Importer(store=store, data_root=data_root, manifest_path=manifest)
+    summary = importer.import_season()
+    return summary.as_dict()
+
+
+def _extract_historical_records(db_path: Path) -> tuple[list[dict], list[int]]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        season_rows = conn.execute(
+            "SELECT season_number FROM seasons ORDER BY season_number"
+        ).fetchall()
+        available_seasons = [int(row["season_number"]) for row in season_rows]
+
+        fight_rows = conn.execute(
+            (
+                "SELECT f.id, f.fight_code, f.fight_number, f.ordinal, f.letter, "
+                "t.tour_number, s.season_number "
+                "FROM fights f "
+                "JOIN tours t ON f.tour_id = t.id "
+                "JOIN seasons s ON t.season_id = s.id "
+                "ORDER BY s.season_number, t.tour_number, f.ordinal"
+            )
+        ).fetchall()
+
+        fights: list[dict] = []
+        for fight_row in fight_rows:
+            fight_id = int(fight_row["id"])
+            participant_rows = conn.execute(
+                (
+                    "SELECT display_name, normalized_name, seat_index, total_score "
+                    "FROM fight_participants WHERE fight_id = ? ORDER BY seat_index"
+                ),
+                (fight_id,),
+            ).fetchall()
+            participants = [
+                {
+                    "display": str(row["display_name"]),
+                    "normalized": str(row["normalized_name"]),
+                    "total": int(row["total_score"]),
+                }
+                for row in participant_rows
+            ]
+            fights.append(
+                {
+                    "season_number": int(fight_row["season_number"]),
+                    "tour_number": int(fight_row["tour_number"]),
+                    "fight_code": str(fight_row["fight_code"]),
+                    "ordinal": int(fight_row["ordinal"]),
+                    "letter": fight_row["letter"],
+                    "participants": participants,
+                }
+            )
+
+        return fights, available_seasons
+    finally:
+        conn.close()

--- a/app/season2/importer.py
+++ b/app/season2/importer.py
@@ -215,14 +215,15 @@ class Season2Importer:
 
             cursor = conn.execute(
                 (
-                    "INSERT INTO fights (tour_id, fight_number, ordinal, fight_code, imported_at, source_path, import_id) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)"
+                    "INSERT INTO fights (tour_id, fight_number, ordinal, fight_code, letter, imported_at, source_path, import_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
                 ),
                 (
                     tour_id,
                     fight.ordinal,
                     fight.ordinal,
                     fight_code,
+                    None,
                     time.time(),
                     str(csv_path),
                     import_id,

--- a/app/season2/results_store.py
+++ b/app/season2/results_store.py
@@ -114,6 +114,7 @@ class Season2ResultsStore:
                 fight_number INTEGER NOT NULL,
                 ordinal INTEGER NOT NULL,
                 fight_code TEXT NOT NULL UNIQUE,
+                letter TEXT,
                 imported_at REAL NOT NULL,
                 source_path TEXT,
                 import_id INTEGER REFERENCES imports(id) ON DELETE SET NULL,
@@ -121,6 +122,7 @@ class Season2ResultsStore:
             )
             """
         )
+        self._ensure_column(conn, "fights", "letter", "TEXT")
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS fight_participants (
@@ -189,6 +191,16 @@ class Season2ResultsStore:
                 ON question_results (question_id)
             """
         )
+
+    def _ensure_column(
+        self, conn: sqlite3.Connection, table: str, column: str, definition: str
+    ) -> None:
+        columns = {
+            row["name"]
+            for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        if column not in columns:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
 
     def _seed_baseline_seasons(self, conn: sqlite3.Connection) -> None:
         for season_number in (1, 2):

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1017,8 +1017,14 @@ select:focus {
 
 .historical-filter__controls {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
+}
+
+.historical-filter__controls label {
+  font-weight: 600;
+  font-size: 0.9rem;
 }
 
 .historical-filter select {

--- a/app/templates/historical_results.html
+++ b/app/templates/historical_results.html
@@ -7,20 +7,27 @@
     <div class="historical-intro">
       <h2 class="card-title">История боёв</h2>
       <p class="card-description">
-        {% if season_number %}
-          Сезон {{ season_number }}. Выберите игрока, чтобы увидеть его результаты в боях.
+        {% if selected_season %}
+          Показаны результаты сезона {{ selected_season }}. Выберите игрока, чтобы увидеть его бои.
         {% else %}
-          Выберите игрока, чтобы увидеть его результаты в боях.
+          Выберите сезон и игрока, чтобы посмотреть результаты боёв.
         {% endif %}
       </p>
     </div>
     <form class="historical-filter" method="get">
-      <label class="field-label" for="player">Игрок</label>
       <div class="historical-filter__controls">
+        <label class="field-label" for="season">Сезон</label>
+        <select id="season" name="season" onchange="this.form.submit()">
+          <option value="">Все сезоны</option>
+          {% for season in available_seasons %}
+            <option value="{{ season }}" {% if season == selected_season %}selected{% endif %}>Сезон {{ season }}</option>
+          {% endfor %}
+        </select>
+        <label class="field-label" for="player">Игрок</label>
         <select id="player" name="player" onchange="this.form.submit()">
           <option value="">Все игроки</option>
           {% for player_name in all_players %}
-            <option value="{{ player_name }}" {% if player_name == selected_player %}selected{% endif %}>{{ player_name }}</option>
+            <option value="{{ player_name }}" {% if player_name == selected_player_canonical %}selected{% endif %}>{{ player_name }}</option>
           {% endfor %}
         </select>
         {% if selected_player %}
@@ -43,7 +50,9 @@
       {% for fight in fights %}
         <article class="historical-fight">
           <header class="historical-fight__header">
-            <h3 class="historical-fight__title">Тур {{ fight.tour_number }}, бой {{ fight.letter or fight.fight_code }}</h3>
+            <h3 class="historical-fight__title">
+              Сезон {{ fight.season_number }}, тур {{ fight.tour_number }}, бой {{ fight.letter or "%02d"|format(fight.ordinal) }}
+            </h3>
             <p class="historical-fight__code">{{ fight.fight_code }}</p>
           </header>
           <table class="historical-table">
@@ -56,7 +65,7 @@
             </thead>
             <tbody>
               {% for player in fight.players %}
-                <tr class="{% if selected_player_found and player.name == selected_player %}historical-player--highlight{% endif %}">
+                <tr class="{% if selected_player_found and player.canonical_name == selected_player_canonical %}historical-player--highlight{% endif %}">
                   <td>{{ loop.index }}</td>
                   <td>{{ player.name or '—' }}</td>
                   <td>{{ player.total }}</td>

--- a/scripts/build_historical_results_db.py
+++ b/scripts/build_historical_results_db.py
@@ -1,0 +1,76 @@
+"""Compile historical fight results for seasons 1 and 2 into a SQLite bundle."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.historical_results_loader import (
+    DEFAULT_SEASON1_FIXTURE,
+    DEFAULT_SEASON2_DATA_ROOT,
+    DEFAULT_SEASON2_MANIFEST,
+    build_historical_database,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--season1-json",
+        type=Path,
+        default=DEFAULT_SEASON1_FIXTURE,
+        help="Path to the Season 1 tour results fixture.",
+    )
+    parser.add_argument(
+        "--season2-data-root",
+        type=Path,
+        default=DEFAULT_SEASON2_DATA_ROOT,
+        help="Directory with Season 2 CSV tour snapshots.",
+    )
+    parser.add_argument(
+        "--season2-manifest",
+        type=Path,
+        default=DEFAULT_SEASON2_MANIFEST,
+        help="Manifest describing Season 2 worksheets.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("app/static/data/historical_results.sqlite3"),
+        help="Destination SQLite database path.",
+    )
+    return parser
+
+
+def _format_summary(summary: dict[str, dict[str, int]]) -> str:
+    lines = ["Historical results database generated:"]
+    for season, stats in sorted(summary.items()):
+        lines.append(f"  {season}:")
+        for key, value in sorted(stats.items()):
+            lines.append(f"    {key.replace('_', ' ')}: {value}")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    summary = build_historical_database(
+        season1_json=args.season1_json,
+        season2_data_root=args.season2_data_root,
+        season2_manifest=args.season2_manifest,
+        output=args.output,
+    )
+    print(_format_summary(summary))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a historical results loader that assembles seasons 1 and 2 from the text snapshots at runtime and caches the payload
- update the historical results view to consume the cached dataset so the committed SQLite bundle can be removed
- reuse the new loader from the helper CLI to continue generating an on-disk database when needed

## Testing
- python scripts/build_historical_results_db.py
- pytest tests/season2/test_importer.py
- pytest tests/season2/test_results_store.py

------
https://chatgpt.com/codex/tasks/task_e_68dc342c914483239ac1fc57bf604fe5