### PR TITLE
Render Google Sheets data with native styling

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -199,6 +199,115 @@ select:focus {
   background: var(--accent-hover);
 }
 
+.link {
+  color: var(--accent);
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.link:hover,
+.link:focus-visible {
+  color: var(--accent-hover);
+}
+
+.sheet-card {
+  gap: 1.5rem;
+}
+
+.sheet-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem 2rem;
+}
+
+.sheet-card__meta {
+  margin: 0;
+  font-weight: 600;
+  color: var(--accent);
+  background: rgba(255, 183, 3, 0.08);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+}
+
+.sheet-card__table-wrapper {
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 20, 43, 0.85);
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.sheet-card__error,
+.sheet-card__empty {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1rem;
+  background: rgba(255, 107, 107, 0.15);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  font-weight: 500;
+}
+
+.sheet-card__empty {
+  background: rgba(111, 123, 247, 0.12);
+  border-color: rgba(111, 123, 247, 0.35);
+}
+
+.sheet-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.sheet-table thead {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.sheet-table th,
+.sheet-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sheet-table th {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.sheet-table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.sheet-table tbody tr:hover {
+  background: rgba(111, 123, 247, 0.12);
+}
+
+.sheet-table td:first-child,
+.sheet-table th:first-child {
+  text-align: center;
+  width: 70px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sheet-table td:nth-child(3) {
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 720px) {
+  .sheet-card__table-wrapper {
+    overflow-x: auto;
+  }
+
+  .sheet-table {
+    min-width: 480px;
+  }
+}
+
 .btn-secondary {
   margin-top: 0.5rem;
 }

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -20,6 +20,10 @@
       <h3>Question Explorer</h3>
       <p>Browse the trivia database, filter by keywords, and try AI-assisted search.</p>
     </a>
+    <a class="placeholder placeholder-link" href="{{ url_for('main.question_source_table') }}">
+      <h3>Таблица Google Sheets</h3>
+      <p>Просматривайте исходные данные напрямую встраивая Google Sheets в Panenka.</p>
+    </a>
     <a class="placeholder placeholder-link" href="{{ url_for('main.historical_results') }}">
       <h3>Исторические бои</h3>
       <p>Просматривайте результаты прошедших боёв и подсвечивайте выбранного игрока.</p>

--- a/app/templates/question_source_table.html
+++ b/app/templates/question_source_table.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}Таблица Google Sheets · Panenka Live{% endblock %}
+{% block layout_modifier %} layout--full{% endblock %}
+{% block content %}
+<section class="card sheet-card">
+  <div class="sheet-card__header">
+    <div>
+      <h2 class="card-title">Таблица Google Sheets</h2>
+      <p class="card-description">
+        На этой странице отображается актуальный список игроков и рейтингов из Google Sheets.
+        Вы можете открыть документ в новой вкладке по
+        <a class="link" href="{{ sheet_direct_url }}" target="_blank" rel="noopener">прямой ссылке</a>.
+      </p>
+    </div>
+    {% if sheet_data.total_rows %}
+      <p class="sheet-card__meta">Всего записей: {{ sheet_data.total_rows }}</p>
+    {% endif %}
+  </div>
+
+  {% if load_error %}
+    <p class="sheet-card__error">{{ load_error }}</p>
+  {% elif sheet_data.rows %}
+    <div class="sheet-card__table-wrapper">
+      <table class="sheet-table">
+        <thead>
+          <tr>
+            {% for column in sheet_data.columns %}
+              <th scope="col">{{ column }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in sheet_data.rows %}
+            <tr>
+              {% for cell in row %}
+                <td data-title="{{ sheet_data.columns[loop.index0] }}">{{ cell }}</td>
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p class="sheet-card__empty">Таблица пуста. Попробуйте позже или откройте Google Sheets напрямую.</p>
+  {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- fetch data from the shared Google Sheet using the gviz JSON endpoint and normalize it for templates
- replace the iframe embed with a styled in-app table that matches the site's presentation and handles error states
- add supporting styles for the sheet view, including responsive table and meta information

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd33beabec83239f5cbbea41d65a0f