### PR TITLE
Implement stage 9 reimport supersession for tour stats

### DIFF
--- a/tests/test_tour_statistics_importer.py
+++ b/tests/test_tour_statistics_importer.py
@@ -262,3 +262,17 @@ def test_imports_two_fights_and_results(store: TourStatisticsStore) -> None:
         assert [row["is_correct"] for row in results] == [1, 0, 0, 0]
 
 
+def test_reimport_supersedes_previous_import(store: TourStatisticsStore) -> None:
+    importer = TourStatisticsImporter(store=store, sheet_id="sheet", sheet_name="S01E02")
+
+    importer.import_rows(SHEET_ROWS)
+    importer.import_rows(SHEET_ROWS)
+
+    with store.connection() as conn:
+        statuses = conn.execute(
+            "SELECT status FROM imports ORDER BY id",
+        ).fetchall()
+
+    assert [row["status"] for row in statuses] == ["superseded", "success"]
+
+


### PR DESCRIPTION
## Summary
- automatically mark prior Google Sheets imports as superseded when a new import succeeds
- adjust integrity triggers so cascaded deletions during reimports do not raise false mismatches
- add a regression test covering the superseded status workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd4fc6ecdc83238dc14aa2cb34dd0b