### PR TITLE
Add seasons 3 and 4 to historical results filters

### DIFF
--- a/app/historical_results_loader.py
+++ b/app/historical_results_loader.py
@@ -54,6 +54,10 @@ def load_historical_dataset(
         )
         fights, seasons = _extract_historical_records(output)
 
+    # Ensure upcoming seasons are visible in the UI filters even before fights
+    # are imported, so the options appear as soon as the season starts.
+    seasons = sorted({*seasons, 3, 4})
+
     raw_names = [
         participant["display"]
         for fight in fights


### PR DESCRIPTION
## Summary
- ensure the historical dataset exposes seasons 3 and 4 so they appear in the filter dropdown

## Testing
- python - <<'PY'
from app.historical_results_loader import load_historical_dataset
print(load_historical_dataset()['seasons'])
PY

------
https://chatgpt.com/codex/tasks/task_e_68dd70e81074832380a2db54daeb8218