### PR TITLE
Normalize quoted player names during tour stats import

### DIFF
--- a/app/tour_statistics_importer.py
+++ b/app/tour_statistics_importer.py
@@ -13,12 +13,18 @@ _FIGHT_CODE_RE = re.compile(
     flags=re.IGNORECASE,
 )
 _NOMINAL_VALUES = {"10", "20", "30", "40", "50"}
+_QUOTE_TRIM_CHARS = '"\'`´‘’‚‛“”„‟«»‹›'
+_QUOTE_CLEAN_RE = re.compile(r'["“”„‟«»‹›]+')
 
 
 def _normalise_text(value: str) -> str:
     value = value.replace("\u00a0", " ")
-    value = re.sub(r"\s+", " ", value.strip().lower())
-    return value.replace("ё", "е")
+    value = value.strip()
+    value = value.strip(_QUOTE_TRIM_CHARS)
+    value = _QUOTE_CLEAN_RE.sub("", value)
+    value = value.strip()
+    value = re.sub(r"\s+", " ", value)
+    return value.lower().replace("ё", "е")
 
 
 def _parse_int(value: str) -> int:


### PR DESCRIPTION
## Summary
- strip stray quotation marks when normalizing player names for tour statistics imports
- cover quoted names in the tour statistics importer tests and ensure fixtures reuse the shared normalizer

## Testing
- pytest tests/test_tour_statistics_importer.py

------
https://chatgpt.com/codex/tasks/task_e_68dd72df77b48323aaf77478f4c6b760