### PR TITLE
Handle empty CLI overrides for results database path

### DIFF
--- a/app/season2/results_store.py
+++ b/app/season2/results_store.py
@@ -14,13 +14,24 @@ class Season2ResultsStore:
     """Manage the database schema used for Season 2 tour results."""
 
     def __init__(self, db_path: Optional[str] = None, *, enable_season_seed: bool = True) -> None:
-        configured_path = db_path or os.getenv("PANENKA_RESULTS_DB")
+        configured_path = db_path
+        if configured_path is None:
+            configured_path = os.getenv("PANENKA_RESULTS_DB")
+
+        if isinstance(configured_path, str):
+            configured_path = configured_path.strip()
+
         if configured_path:
             base_path = Path(configured_path).expanduser()
             if not base_path.is_absolute():
                 base_path = (Path.cwd() / base_path).resolve()
             else:
                 base_path = base_path.resolve()
+            if base_path.exists() and base_path.is_dir():
+                raise ValueError(
+                    f"Configured results database path '{base_path}' is a directory; "
+                    "provide a SQLite filename instead."
+                )
         else:
             base_path = Path(__file__).resolve().parent / "season2_results.sqlite3"
 

--- a/scripts/season2/bootstrap_results_schema.py
+++ b/scripts/season2/bootstrap_results_schema.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
-
 from app.season2 import Season2ResultsStore
 
 
@@ -14,7 +12,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--database",
         dest="database",
-        type=Path,
         help="Path to the results database (defaults to PANENKA_RESULTS_DB or app/season2/season2_results.sqlite3)",
     )
     parser.add_argument(
@@ -28,10 +25,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    store = Season2ResultsStore(
-        db_path=str(args.database) if args.database else None,
-        enable_season_seed=args.seed,
-    )
+    configured_path = (args.database or "").strip() or None
+    store = Season2ResultsStore(db_path=configured_path, enable_season_seed=args.seed)
     store.ensure_schema()
     print(f"Ensured Season 2 results schema at {store.db_path}")
 

--- a/scripts/season2/import_results.py
+++ b/scripts/season2/import_results.py
@@ -24,7 +24,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--db-path",
-        type=Path,
         help="Optional override for the results database path.",
     )
     parser.add_argument(
@@ -40,7 +39,8 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    store = Season2ResultsStore(db_path=str(args.db_path) if args.db_path else None)
+    configured_path = (args.db_path or "").strip() or None
+    store = Season2ResultsStore(db_path=configured_path)
     importer = Season2Importer(store=store, data_root=args.data_root, manifest_path=args.manifest)
 
     summary = importer.import_season(tours=args.tours)

--- a/tests/test_historical_results_loader.py
+++ b/tests/test_historical_results_loader.py
@@ -1,7 +1,11 @@
+import time
+
 from app.historical_results_loader import load_historical_dataset
+from app.season2 import Season2ResultsStore
 
 
 def test_future_season_fixtures_are_loaded():
+    load_historical_dataset.cache_clear()
     dataset = load_historical_dataset()
 
     assert 3 in dataset["seasons"]
@@ -9,3 +13,76 @@ def test_future_season_fixtures_are_loaded():
 
     fight_seasons = {fight.get("season_number") for fight in dataset["fights"]}
     assert {3, 4}.issubset(fight_seasons)
+
+
+def test_dataset_uses_database_when_available(tmp_path, monkeypatch):
+    load_historical_dataset.cache_clear()
+
+    db_path = tmp_path / "results.sqlite3"
+    store = Season2ResultsStore(db_path=str(db_path), enable_season_seed=False)
+
+    with store.connection() as conn:
+        for season_number in range(1, 5):
+            season_slug = f"{season_number:02d}"
+            season_row = conn.execute(
+                "SELECT id FROM seasons WHERE season_number = ?", (season_number,)
+            ).fetchone()
+            if season_row is None:
+                cursor = conn.execute(
+                    "INSERT INTO seasons (season_number, slug) VALUES (?, ?)",
+                    (season_number, season_slug),
+                )
+                season_id = int(cursor.lastrowid)
+            else:
+                season_id = int(season_row["id"])
+
+            tour_cursor = conn.execute(
+                "INSERT INTO tours (season_id, tour_number, gid) VALUES (?, ?, ?)",
+                (season_id, 1, None),
+            )
+            tour_id = int(tour_cursor.lastrowid)
+
+            fight_code = f"S{season_number:02d}E01F01"
+            fight_cursor = conn.execute(
+                (
+                    "INSERT INTO fights (tour_id, fight_number, ordinal, fight_code, letter, "
+                    "imported_at, source_path, import_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                ),
+                (tour_id, 1, 1, fight_code, "A", time.time(), None, None),
+            )
+            fight_id = int(fight_cursor.lastrowid)
+
+            player_name = f"Season {season_number} DB Player"
+            conn.execute(
+                (
+                    "INSERT INTO fight_participants (fight_id, display_name, normalized_name, "
+                    "seat_index, total_score) VALUES (?, ?, ?, ?, ?)"
+                ),
+                (fight_id, player_name, player_name.lower(), 1, 100 - season_number),
+            )
+
+        conn.commit()
+
+    monkeypatch.setenv("PANENKA_RESULTS_DB", str(db_path))
+
+    try:
+        dataset = load_historical_dataset()
+    finally:
+        load_historical_dataset.cache_clear()
+        monkeypatch.delenv("PANENKA_RESULTS_DB", raising=False)
+
+    fight_codes = {fight.get("fight_code") for fight in dataset["fights"]}
+    assert fight_codes == {
+        "S01E01F01",
+        "S02E01F01",
+        "S03E01F01",
+        "S04E01F01",
+    }
+
+    player_names = {
+        participant.get("display")
+        for fight in dataset["fights"]
+        for participant in fight.get("participants", [])
+    }
+    assert "Season 3 DB Player" in player_names
+    assert "Season 4 DB Player" in player_names


### PR DESCRIPTION
## Summary
- make the bootstrap and import CLIs ignore blank database overrides so they fall back to defaults
- trim environment-provided paths and surface a clear error when a directory is supplied for the SQLite database

## Testing
- pytest tests/test_historical_results_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68de5232d0248323be81fcc981384979