### PR TITLE
Fix visibility toggles for Game 10 panels

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -17,6 +17,11 @@
   box-sizing: border-box;
 }
 
+[hidden],
+.is-hidden {
+  display: none !important;
+}
+
 body {
   min-height: 100vh;
   margin: 0;

--- a/app/templates/game_ten.html
+++ b/app/templates/game_ten.html
@@ -133,6 +133,21 @@
     const timerControllers = new Map();
     let saveTimerId = null;
 
+    function setSectionVisibility(section, shouldShow) {
+      if (!section) {
+        return;
+      }
+      if (shouldShow) {
+        section.hidden = false;
+        section.classList.remove('is-hidden');
+        section.setAttribute('aria-hidden', 'false');
+      } else {
+        section.hidden = true;
+        section.classList.add('is-hidden');
+        section.setAttribute('aria-hidden', 'true');
+      }
+    }
+
     function showError(message) {
       if (!errorNode) {
         return;
@@ -954,12 +969,8 @@
     function showQuestionSelection(state, { skipSave = false } = {}) {
       const selection = gameRoot.querySelector('[data-role="question-selection"]');
       const questionView = gameRoot.querySelector('[data-role="question-view"]');
-      if (selection) {
-        selection.hidden = false;
-      }
-      if (questionView) {
-        questionView.hidden = true;
-      }
+      setSectionVisibility(selection, true);
+      setSectionVisibility(questionView, false);
       const revealBody = gameRoot.querySelector('[data-role="reveal-body"]');
       if (revealBody) {
         revealBody.textContent = '';
@@ -1148,12 +1159,8 @@
 
       const selection = gameRoot.querySelector('[data-role="question-selection"]');
       const questionView = gameRoot.querySelector('[data-role="question-view"]');
-      if (selection) {
-        selection.hidden = true;
-      }
-      if (questionView) {
-        questionView.hidden = false;
-      }
+      setSectionVisibility(selection, false);
+      setSectionVisibility(questionView, true);
 
       const questionState = ensureQuestionState(state, questionMeta);
       if (!questionState) {


### PR DESCRIPTION
## Summary
- ensure the Game 10 question selection and answer view hide each other using a shared helper
- add a global utility rule so hidden sections are fully removed from the layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0d3426afc8323a86537207cd859c6